### PR TITLE
fix: use a board that *actually uses* selenium in tests

### DIFF
--- a/tests.yaml
+++ b/tests.yaml
@@ -1,4 +1,4 @@
-# Keymap Checks: dummy keeb + command-line options
+# Keymap Checks: default keeb + command-line options
 
 include:
 

--- a/tests.yaml
+++ b/tests.yaml
@@ -3,26 +3,22 @@
 include:
 
   # default config
-  - board: sparkfun_pro_micro_rp2040//zmk
-    shield: tester_pro_micro
+  - board: quacken_flex/rp2040
     artifact-name: tester_rp2040
     cmake-args: -DDTS_EXTRA_CPPFLAGS="-DCI_IGNORE_USER_SETTINGS"
 
   # Qwerty + Vim + hrm_shift
-  - board: sparkfun_pro_micro_rp2040//zmk
-    shield: tester_pro_micro
+  - board: quacken_flex/rp2040
     artifact-name: tester_rp2040_qwerty_vim_shift
     cmake-args: -DDTS_EXTRA_CPPFLAGS="-DCI_IGNORE_USER_SETTINGS;-DVIM_NAVIGATION;-DHRM_SHIFT"
 
   # Azerty + thumb-taps
-  - board: sparkfun_pro_micro_rp2040//zmk
-    shield: tester_pro_micro
+  - board: quacken_flex/rp2040
     artifact-name: tester_rp2040_azerty_tt
     cmake-args: -DDTS_EXTRA_CPPFLAGS="-DCI_IGNORE_USER_SETTINGS;-DKB_LAYOUT_AZERTY;-DHT_THUMB_TAPS"
 
   # Ergol + Hummingbird
-  - board: sparkfun_pro_micro_rp2040//zmk
-    shield: tester_pro_micro
+  - board: quacken_flex/rp2040
     artifact-name: tester_rp2040_ergol_hummingbird
     cmake-args: -DDTS_EXTRA_CPPFLAGS="-DCI_IGNORE_USER_SETTINGS;-DKB_LAYOUT_ERGOL;-DHUMMINGBIRD"
 
@@ -32,19 +28,16 @@ include:
     cmake-args: -DDTS_EXTRA_CPPFLAGS="-DCI_IGNORE_USER_SETTINGS;-DHT_HOME_ROW_MODS"
 
   # Dvorak emulation on Qwerty
-  - board: sparkfun_pro_micro_rp2040//zmk
-    shield: tester_pro_micro
+  - board: quacken_flex/rp2040
     artifact-name: tester_qwerty_to_dvorak
     cmake-args: -DDTS_EXTRA_CPP_FLAGS="-DCI_IGNORE_USER_SETTINGS;-DKB_LAYOUT_QWERTY;-DKB_EMULATION_DVORAK"
 
   # Ergol emulation on Azerty
-  - board: sparkfun_pro_micro_rp2040//zmk
-    shield: tester_pro_micro
+  - board: quacken_flex/rp2040
     artifact-name: tester_azerty_to_ergol
     cmake-args: -DDTS_EXTRA_CPP_FLAGS="-DCI_IGNORE_USER_SETTINGS;-DKB_LAYOUT_AZERTY;-DKB_EMULATION_ERGOL"
 
   # Ergol emulation on Qwerty-intl
-  - board: sparkfun_pro_micro_rp2040//zmk
-    shield: tester_pro_micro
+  - board: quacken_flex/rp2040
     artifact-name: tester_qwerty_intl_to_ergol
     cmake-args: -DDTS_EXTRA_CPP_FLAGS="-DCI_IGNORE_USER_SETTINGS;-DKB_LAYOUT_QWERTY_INTL;-DKB_EMULATION_ERGOL"


### PR DESCRIPTION
After completely nuking the build CI by accident upon opening #6 as a draft, and seeing that *somehow* the tests still stood (aside from the ferris), I realized that due to us using the tester shield with no explicit keymap, we aren’t actually building Selenium in those tests (just the default keymap for that shield).

I propose using the `quacken_flex` as the board of choice for those tests. Not just because it’s our little baby, but also because it’s only a single board without any special jank (like the ferris), so it should be a bit easier to maintain, in the long run.

Since the Quacken is *so simple* (it doesn’t require any binding or special config), we could also pass the keymap explicitly using the cmake args, and keep the generic tester shields. Idk which one is cleaner tbh.