### PR TITLE
refactor: better emulation abstraction layer

### DIFF
--- a/keymaps/aliases/azerty.h
+++ b/keymaps/aliases/azerty.h
@@ -31,7 +31,7 @@
 #define S_AMPS  &kp N1
 #define S_STAR  &kp BSLH
 #define S_SQT   &kp N4
-#define S_GRAVE &spc RA(N7)
+#define S_GRAVE &digraph RA(N7) SPACE
 
 // second row
 #define S_LBRC  &kp RA(N4)
@@ -46,7 +46,7 @@
 #define S_DQT   &kp N3
 
 // third row
-#define S_TILDE &spc RA(N2)
+#define S_TILDE &digraph RA(N2) SPACE
 #define S_LBKT  &kp RA(N5)
 #define S_RBKT  &kp RA(MINUS)
 #define S_UNDER &kp N8
@@ -61,3 +61,51 @@
 #define S_COMMA &kp M
 #define S_DOT   &kp LS(COMMA)
 #define S_MONEY &kp RA(E)
+
+// GRAVE and TILDE are no dead keys on Linux
+#ifdef LINUX
+  #undef S_GRAVE
+  #define S_GRAVE &kp RA(N7)
+  #undef S_TILDE
+  #define S_TILDE &kp RA(N2)
+#endif
+
+
+/**
+ * Non-ASCII Symbols
+ * https://commons.wikimedia.org/wiki/File:KB_-_AZERTY_-_FR_-_Windows_-_FR.png
+ */
+
+#define C_EACU &kp N2  // é
+#define C_AGRV &kp N0  // à
+#define C_EGRV &kp N7  // è
+#define C_UGRV &kp SQT // ù
+#define C_CCDL &kp N9  // ç
+
+#ifdef LINUX
+  #define C_OE   &kp RA(K) // œ
+  #define C_AE   &kp RA(X) // æ
+  #define C_NTLD &kp N // unsupported
+#else
+  #define C_OE   &digraph O E // unsupported
+  #define C_AE   &digraph Q E // unsupported
+  #define C_NTLD &digraph RA(N2) N // ñ
+#endif
+
+#define C_MU &kp PIPE // µ
+
+// circumflex accent
+#define C_ACRC &digraph LBKT Q // â
+#define C_ECRC &digraph LBKT E // ê
+#define C_ICRC &digraph LBKT I // î
+#define C_OCRC &digraph LBKT O // ô
+#define C_UCRC &digraph LBKT U // û
+#define C_YCRC &digraph LBKT Y // ŷ
+
+// diaeresis
+#define C_ADIA &digraph LBRC Q // ä
+#define C_EDIA &digraph LBRC E // ë
+#define C_IDIA &digraph LBRC I // ï
+#define C_ODIA &digraph LBRC O // ö
+#define C_UDIA &digraph LBRC U // ü
+#define C_YDIA &digraph LBRC Y // ÿ

--- a/keymaps/aliases/qwerty_intl.h
+++ b/keymaps/aliases/qwerty_intl.h
@@ -22,7 +22,7 @@
  */
 
 // first row
-#define S_CARET &spc CARET
+#define S_CARET &digraph CARET SPACE
 #define S_LT    &kp LT
 #define S_GT    &kp GT
 #define S_DLLR  &kp DLLR
@@ -30,8 +30,8 @@
 #define S_AT    &kp AT
 #define S_AMPS  &kp AMPS
 #define S_STAR  &kp STAR
-#define S_SQT   &spc SQT
-#define S_GRAVE &spc GRAVE
+#define S_SQT   &digraph SQT SPACE
+#define S_GRAVE &digraph GRAVE SPACE
 
 // second row
 #define S_LBRC  &kp LBRC
@@ -43,10 +43,10 @@
 #define S_PLUS  &kp PLUS
 #define S_MINUS &kp MINUS
 #define S_FSLH  &kp FSLH
-#define S_DQT   &spc DQT
+#define S_DQT   &digraph DQT SPACE
 
 // third row
-#define S_TILDE &kp TILDE
+#define S_TILDE &digraph TILDE SPACE
 #define S_LBKT  &kp LBKT
 #define S_RBKT  &kp RBKT
 #define S_UNDER &kp UNDER
@@ -61,3 +61,141 @@
 #define S_COMMA &kp COMMA
 #define S_DOT   &kp DOT
 #define S_MONEY &kp DLLR
+
+
+/**
+ * Non-ASCII Symbols
+ * https://commons.wikimedia.org/wiki/File:KB_US-International.svg
+ */
+
+#define SA(key) RS(RA(key))
+
+// acute accent + cedilla
+#define  C_AACU &digraph SQT A     // á
+#define SC_AACU &digraph SQT RS(A) // Á
+#define  C_EACU &digraph SQT E     // é
+#define SC_EACU &digraph SQT RS(E) // É
+#define  C_IACU &digraph SQT I     // í
+#define SC_IACU &digraph SQT RS(I) // Í
+#define  C_OACU &digraph SQT O     // ó
+#define SC_OACU &digraph SQT RS(O) // Ó
+#define  C_UACU &digraph SQT U     // ú
+#define SC_UACU &digraph SQT RS(U) // Ú
+#define  C_YACU &digraph SQT Y     // ý
+#define SC_YACU &digraph SQT RS(Y) // Ý
+#define  C_CCDL &digraph SQT C     // ç
+#define SC_CCDL &digraph SQT RS(C) // ç
+
+// grave accent
+#define  C_AGRV &digraph GRAVE A     // à
+#define SC_AGRV &digraph GRAVE RS(A) // À
+#define  C_EGRV &digraph GRAVE E     // è
+#define SC_EGRV &digraph GRAVE RS(E) // È
+#define  C_IGRV &digraph GRAVE I     // ì
+#define SC_IGRV &digraph GRAVE RS(I) // Ì
+#define  C_OGRV &digraph GRAVE O     // ò
+#define SC_OGRV &digraph GRAVE RS(O) // Ò
+#define  C_UGRV &digraph GRAVE U     // ù
+#define SC_UGRV &digraph GRAVE RS(U) // Ù
+#define  C_YGRV &digraph GRAVE Y     // ỳ
+#define SC_YGRV &digraph GRAVE RS(Y) // Ỳ
+
+// circumflex accent
+#define  C_ACRC &digraph CARET A     // â
+#define SC_ACRC &digraph CARET RS(A) // Â
+#define  C_ECRC &digraph CARET E     // ê
+#define SC_ECRC &digraph CARET RS(E) // Ê
+#define  C_ICRC &digraph CARET I     // î
+#define SC_ICRC &digraph CARET RS(I) // Î
+#define  C_OCRC &digraph CARET O     // ô
+#define SC_OCRC &digraph CARET RS(O) // Ô
+#define  C_UCRC &digraph CARET U     // û
+#define SC_UCRC &digraph CARET RS(U) // Û
+#define  C_YCRC &digraph CARET Y     // ŷ
+#define SC_YCRC &digraph CARET RS(Y) // Ŷ
+
+// diaeresis
+#define  C_ADIA &digraph DQT A     // ä
+#define SC_ADIA &digraph DQT RS(A) // Ä
+#define  C_EDIA &digraph DQT E     // ë
+#define SC_EDIA &digraph DQT RS(E) // Ë
+#define  C_IDIA &digraph DQT I     // ï
+#define SC_IDIA &digraph DQT RS(I) // Ï
+#define  C_ODIA &digraph DQT O     // ö
+#define SC_ODIA &digraph DQT RS(O) // Ö
+#define  C_UDIA &digraph DQT U     // ü
+#define SC_UDIA &digraph DQT RS(U) // Ü
+#define  C_YDIA &digraph DQT Y     // ÿ
+#define SC_YDIA &digraph DQT RS(Y) // Ÿ
+
+// tilde
+#define  C_ATLD &digraph TILDE A     // ã
+#define SC_ATLD &digraph TILDE RS(A) // Ã
+#define  C_ETLD &digraph TILDE E     // ẽ
+#define SC_ETLD &digraph TILDE RS(E) // Ẽ
+#define  C_ITLD &digraph TILDE I     // ĩ
+#define SC_ITLD &digraph TILDE RS(I) // Ĩ
+#define  C_OTLD &digraph TILDE O     // õ
+#define SC_OTLD &digraph TILDE RS(O) // Õ
+#define  C_UTLD &digraph TILDE U     // ũ
+#define SC_UTLD &digraph TILDE RS(U) // Ũ
+#define  C_YTLD &digraph TILDE Y     // ỹ
+#define SC_YTLD &digraph TILDE RS(Y) // Ỹ
+#define  C_NTLD &digraph TILDE N     // ñ
+#define SC_NTLD &digraph TILDE RS(N) // Ñ
+
+// spectal letters
+#ifdef LINUX
+  #define  C_OE  &kp RA(K) // œ
+  #define SC_OE  &kp SA(K) // Œ
+#else
+  #define  C_OE  &digraph O E
+  #define SC_OE  &digraph LS(O) LS(E)
+#endif
+#define  C_AE    &kp RA(X) // æ
+#define SC_AE    &kp SA(X) // Æ
+#define  C_ARING &kp RA(W) // å
+#define SC_ARING &kp SA(W) // Å
+#define  C_OSTRK &kp RA(L) // ø
+#define SC_OSTRK &kp SA(L) // Ø
+#define  C_ETH   &kp RA(D) // ð
+#define SC_ETH   &kp SA(D) // Ð
+#define  C_THORN &kp RA(R) // Þ
+#define SC_THORN &kp SA(R) // þ
+#define  C_SZ    &kp RA(S) // ß
+
+// punctuation
+#define C_LSQT  &kb RA(N9)    // ‘
+#define C_RSQT  &kb RA(N0)    // ’
+#define C_LDQT  &kb RA(LBRC)  // “
+#define C_RDQT  &kb RA(RBRC)  // ”
+#define C_LGQT  &kb RA(LBKT)  // «
+#define C_RGQT  &kb RA(RBKT)  // «
+#define C_SECT  &kb SA(S)     // §
+#define C_PAR   &kb RA(SEMI)  // ¶
+#define C_LCXE  &kb RA(N1)    // ¡
+#define C_KRAMQ &kb RA(FSLH)  // ¿
+
+// currencies
+#define C_CURR  &kb RA(N4)    // ¤
+#define C_POUND &kb SA(N4)    // £
+#define C_EURO  &kb RA(N5)    // €
+#define C_YEN   &kb RA(MINUS) // ¥
+#define C_COPY  &kb RA(C)     // ©
+#define C_CENT  &kb SA(C)     // ¢
+#define C_RGSTR &kb RA(R)     // ®
+#define C_TM    &kb SA(R)     // ™
+
+// math
+#define C_DEG   &kb SA(SEMI)  // °
+#define C_BPIPE &kb SA(BSLH)  // ¦
+#define C_NOT   &kb RA(BSLH)  // ¬
+#define C_DIV   &kb SA(EQUAL) // ÷
+#define C_MULT  &kb RA(EQUAL) // ×
+#define C_EXP1  &kb SA(N1)    // ¹
+#define C_EXP2  &kb RA(N2)    // ²
+#define C_EXP3  &kb RA(N3)    // ³
+#define C_QRT1  &kb RA(N6)    // ¼
+#define C_QRT2  &kb RA(N7)    // ½
+#define C_QRT3  &kb RA(N8)    // ¾
+#define C_MU    &kp RA(M)     // µ

--- a/keymaps/emulations/ergol.dtsi
+++ b/keymaps/emulations/ergol.dtsi
@@ -1,127 +1,82 @@
 #define ODK_LAYER        EXTRA_LAYERS_START_INDEX
 #define ODK_SHIFT_LAYER (EXTRA_LAYERS_START_INDEX + 1)
 
-#define PUNCTUATION_KEY(name, base, shift) name: name { \
-  compatible = "zmk,behavior-mod-morph";                \
-  #binding-cells = <0>;                                 \
-  bindings = <base>, <shift>;                           \
-  mods      = <(MOD_LSFT|MOD_RSFT)>;                    \
-  keep-mods = <(MOD_LSFT|MOD_RSFT)>;                    \
-};
-
 / {
   behaviors {
-    PUNCTUATION_KEY(apos, &EZ_SL(ODK_LAYER), S_EXCL) // ' ! (1dk)
-    PUNCTUATION_KEY(dash,  S_MINUS, S_QMARK)         // - ?
-    PUNCTUATION_KEY(dot,   S_DOT,   S_COLON)         // . :
-    PUNCTUATION_KEY(comma, S_COMMA, S_SEMI)          // , ;
+    TWO_LEVEL_KEY(apos, &EZ_SL(ODK_LAYER), S_EXCL) // ' ! (1dk)
+    TWO_LEVEL_KEY(dash,  S_MINUS, S_QMARK)         // - ?
+    TWO_LEVEL_KEY(dot,   S_DOT,   S_COLON)         // . :
+    TWO_LEVEL_KEY(comma, S_COMMA, S_SEMI)          // , ;
   };
 };
 
 
 /******************************************************************************
- * AZERTY host
+ * Base Layer (host-specific)
 ******************************************************************************/
 
 #ifdef KB_LAYOUT_AZERTY
 
-&base_layer {
-  display-name = "Base";
-  bindings = <SELENIUM_KEYMAP_BINDINGS(
-    &none  ,  &kp A  &kp C  &kp O  &kp P  &kp Z   ,   &kp J  &kp SEMI &kp D  &apos  &kp Y     ,  &none ,
-    &none  ,  H_A Q  H_S S  H_D E  H_F N  &kp F   ,   &kp L  H_J R    H_K T  H_L I  H_SEMI U  ,  &none ,
-    &none  ,  &kp W  &kp X  &dash  &kp V  &kp B   ,   &dot   &kp H    &kp G  &comma &kp K     ,  &none ,
-       LTHUMB_TUCK , LTHUMB_HOME , LTHUMB_REACH   ,   RTHUMB_REACH , RTHUMB_HOME , RTHUMB_TUCK
-  )>;
-};
-
-/ {
-  macros {
-    DEAD_KEY(crc, &kp LBKT) // circumflex accent
-    i_dia: i_diaeresis {
-      compatible = "zmk,behavior-macro";
-      #binding-cells = <0>;
-      bindings = <&macro_tap &kp LBRC &kp I>;
-    };
-    n_tld: n_tilde {
-      compatible = "zmk,behavior-macro";
-      #binding-cells = <0>;
-      bindings = <&macro_tap &kp RA(N2) &kp N>;
-    };
+  &base_layer {
+    display-name = "Base";
+    bindings = <SELENIUM_KEYMAP_BINDINGS(
+      &none  ,  &kp A  &kp C  &kp O  &kp P  &kp Z   ,   &kp J  &kp SEMI &kp D  &apos  &kp Y     ,  &none ,
+      &none  ,  H_A Q  H_S S  H_D E  H_F N  &kp F   ,   &kp L  H_J R    H_K T  H_L I  H_SEMI U  ,  &none ,
+      &none  ,  &kp W  &kp X  &dash  &kp V  &kp B   ,   &dot   &kp H    &kp G  &comma &kp K     ,  &none ,
+         LTHUMB_TUCK , LTHUMB_HOME , LTHUMB_REACH   ,   RTHUMB_REACH , RTHUMB_HOME , RTHUMB_TUCK
+    )>;
   };
+  #define K_DIA &kp LBRC // diaeresis
+  #define K_ODKS &trans  // no 1dkShift layer
 
-  keymap {
-    compatible = "zmk,keymap";
+#elif defined KB_LAYOUT_QWERTY_INTL
 
-    one_dead_key {
-      display-name = "1dk";
-      bindings = <SELENIUM_KEYMAP_BINDINGS(
-        &trans  ,  &crc Q  &kp N9  &trans  &crc O  &trans   ,   &trans  &kp LS(BSLH) S_UNDER &kp LBRC  &crc U   ,  &trans ,
-        &trans  ,  &kp N0  &kp N2  &kp N7  &crc E  &n_tld   ,   S_LPAR  S_RPAR       &crc I  &i_dia    &kp SQT  ,  &trans ,
-        &trans  ,  &trans  &trans  &trans  &trans  &trans   ,   &trans  &trans       &trans  &trans    &trans   ,  &trans ,
-                                  &trans , S_SQT , &trans   ,   &trans , S_SQT , &trans
-      )>;
-    };
+  &base_layer {
+    display-name = "Base";
+    bindings = <SELENIUM_KEYMAP_BINDINGS(
+      &none  ,  &kp Q  &kp C  &kp O  &kp P  &kp W   ,   &kp J  &kp M  &kp D  &apos  &kp Y     ,  &none ,
+      &none  ,  H_A A  H_S S  H_D E  H_F N  &kp F   ,   &kp L  H_J R  H_K T  H_L I  H_SEMI U  ,  &none ,
+      &none  ,  &kp Z  &kp X  &dash  &kp V  &kp B   ,   &dot   &kp H  &kp G  &comma &kp K     ,  &none ,
+         LTHUMB_TUCK , LTHUMB_HOME , LTHUMB_REACH   ,   RTHUMB_REACH , RTHUMB_HOME , RTHUMB_TUCK
+    )>;
   };
-};
+  #define K_DIA &kp DQT // diaeresis
+  #define K_ODKS &EZ_SL(ODK_SHIFT_LAYER)
+
+#else
+  #error "KB_EMULATION_ERGOL requires either KB_LAYOUT_AZERTY or KB_LAYOUT_QWERTY_INTL"
+#endif
 
 
 /******************************************************************************
- * QWERTY-intl host
+ * 1DK Layers (non-ASCII chars, host-agnostic)
 ******************************************************************************/
 
-#elifdef KB_LAYOUT_QWERTY_INTL
-
-&base_layer {
-  display-name = "Base";
-  bindings = <SELENIUM_KEYMAP_BINDINGS(
-    &none  ,  &kp Q  &kp C  &kp O  &kp P  &kp W   ,   &kp J  &kp M  &kp D  &apos  &kp Y     ,  &none ,
-    &none  ,  H_A A  H_S S  H_D E  H_F N  &kp F   ,   &kp L  H_J R  H_K T  H_L I  H_SEMI U  ,  &none ,
-    &none  ,  &kp Z  &kp X  &dash  &kp V  &kp B   ,   &dot   &kp H  &kp G  &comma &kp K     ,  &none ,
-       LTHUMB_TUCK , LTHUMB_HOME , LTHUMB_REACH   ,   RTHUMB_REACH , RTHUMB_HOME , RTHUMB_TUCK
-  )>;
-};
-
 / {
-  macros {
-    DEAD_KEY(acu, &kp SQT)    // acute accent or cedilla
-    DEAD_KEY(dia, &kp DQT)    // diaeresis
-    DEAD_KEY(grv, &kp GRAVE)  // grave accent
-    DEAD_KEY(crc, &kp CARET)  // circumflex accent
-    DEAD_KEY(tld, &kp TILDE)  // tilde
-
-    DEAD_KEY_SHIFT(acus, &kp SQT)
-    DEAD_KEY_SHIFT(dias, &kp DQT)
-    DEAD_KEY_SHIFT(grvs, &kp GRAVE)
-    DEAD_KEY_SHIFT(crcs, &kp CARET)
-    DEAD_KEY_SHIFT(tlds, &kp TILDE)
-  };
-
   keymap {
     compatible = "zmk,keymap";
 
     one_dead_key {
       display-name = "1dk";
       bindings = <SELENIUM_KEYMAP_BINDINGS(
-        &trans  ,  &crc A  &acu C  &trans  &crc O  &trans   ,   &trans  &trans  S_UNDER &kp DQT &crc U  ,  &trans ,
-        &trans  ,  &grv A  &acu E  &grv E  &crc E  &tld N   ,   S_LPAR  S_RPAR  &crc I  &dia I  &grv U  ,  &trans ,
-        &trans  ,  &trans  &trans  &trans  &trans  &trans   ,   &trans  &trans  &trans  &trans  &trans  ,  &trans ,
-                 &EZ_SL(ODK_SHIFT_LAYER) , S_SQT , &trans   ,   &trans , S_SQT , &trans
+        &trans  ,  C_ACRC  C_CCDL  C_OE    C_OCRC  &trans   ,   &trans  C_MU    S_UNDER K_DIA   C_UCRC  ,  &trans ,
+        &trans  ,  C_AGRV  C_EACU  C_EGRV  C_ECRC  C_NTLD   ,   S_LPAR  S_RPAR  C_ICRC  C_IDIA  C_UGRV  ,  &trans ,
+        &trans  ,  C_AE    &trans  &trans  &trans  &trans   ,   &trans  &trans  &trans  &trans  &trans  ,  &trans ,
+                                  &trans , S_SQT , &trans   ,   &trans , S_SQT , &trans
       )>;
     };
 
+#ifdef KB_LAYOUT_QWERTY_INTL
     one_dead_key_shift {
       display-name = "1dkShift";
       bindings = <SELENIUM_KEYMAP_BINDINGS(
-        &trans  ,  &crcs A &acus C &trans  &crcs O &trans   ,   &trans  &trans  S_UNDER &kp DQT &crcs U  ,  &trans ,
-        &trans  ,  &grvs A &acus E &grvs E &crcs E &tlds N  ,   &trans  &trans  &crcs I &dias I &grvs U  ,  &trans ,
-        &trans  ,  &trans  &trans  &trans  &trans  &trans   ,   &trans  &trans  &trans  &trans  &trans   ,  &trans ,
+        &trans  ,  SC_ACRC SC_CCDL SC_OE   SC_OCRC &trans   ,   &trans  &trans  S_UNDER K_DIA   SC_UCRC  ,  &trans ,
+        &trans  ,  SC_AGRV SC_EACU SC_EGRV SC_ECRC SC_NTLD  ,   S_LPAR  S_RPAR  SC_ICRC SC_IDIA SC_UGRV  ,  &trans ,
+        &trans  ,  SC_AE   &trans  &trans  &trans  &trans   ,   &trans  &trans  &trans  &trans  &trans   ,  &trans ,
                                  &trans , &trans , &trans   ,   &trans , &trans , &trans
       )>;
     };
+#endif
+
   };
 };
-
-#else
-#error "KB_EMULATION_ERGOL requires either KB_LAYOUT_AZERTY or KB_LAYOUT_QWERTY_INTL"
-#endif

--- a/keymaps/mappings.dtsi
+++ b/keymaps/mappings.dtsi
@@ -1,8 +1,8 @@
 #include <behaviors.dtsi>
 #include <dt-bindings/zmk/keys.h>
 
+// Define a dead layer key
 // note: macro_pause_for_release might be useless
-
 #define DEAD_KEY(name, key) name: name {       \
   compatible = "zmk,behavior-macro-one-param"; \
   #binding-cells = <1>;                        \
@@ -16,6 +16,8 @@
     ;                                          \
 };
 
+// Define a shifted dead layer key
+// note: macro_pause_for_release might be useless
 #define DEAD_KEY_SHIFT(name, key) name: name { \
   compatible = "zmk,behavior-macro-one-param"; \
   #binding-cells = <1>;                        \
@@ -31,19 +33,24 @@
     ;                                          \
 };
 
+// Define a two-level key (e.g. punctuation key)
+#define TWO_LEVEL_KEY(name, base, shift) name: name { \
+  compatible = "zmk,behavior-mod-morph";              \
+  #binding-cells = <0>;                               \
+  bindings = <base>, <shift>;                         \
+  mods = <(MOD_LSFT|MOD_RSFT)>;                       \
+};
+
 / {
   macros {
-    spc: space_after_dead_key {
-      compatible = "zmk,behavior-macro-one-param";
-      #binding-cells = <1>;
+    digraph: digraph {
+      compatible = "zmk,behavior-macro-two-param";
+      #binding-cells = <2>;
       tap-ms = <0>;
       wait-ms = <0>;
-      bindings
-        = <&macro_param_1to1>
-        , <&kp MACRO_PLACEHOLDER>
-        , <&macro_pause_for_release>
-        , <&macro_tap &kp SPACE>
-        ;
+      bindings = <
+        &macro_param_1to1 &kp MACRO_PLACEHOLDER
+        &macro_param_2to1 &kp MACRO_PLACEHOLDER>;
     };
   };
 };

--- a/keymaps/selenium.keymap
+++ b/keymaps/selenium.keymap
@@ -7,7 +7,7 @@
 
 #include "aliases.h"      // defines symbols and actions
 #include "bindings.h"     // default SELENIUM_KEYMAP_BINDINGS macro
-#include "dead_keys.dtsi" // defines dead key helpers
+#include "mappings.dtsi"  // key mapping helpers and macros
 #include "hold_taps.dtsi" // defines thumb keys and homerow mods
 
 /**


### PR DESCRIPTION
- the base layer remains layout-specific
- layout aliases now define their common non-ASCII symbols
- 1dk / 1dkShift layers only rely on these layout aliases