### PR TITLE
fix: ergol-hummingbird, timings and fn-media layer

### DIFF
--- a/include/aekeynox/extra_layers/ergol_hummingbird.dtsi
+++ b/include/aekeynox/extra_layers/ergol_hummingbird.dtsi
@@ -6,9 +6,9 @@
 &base_layer {
   display-name = "Base";
   bindings = <SELENIUM_KEYMAP_BINDINGS(
-    &kp Z  ,  &kp Q  &kp W  &kp E  &kp R  &kp T   ,   &kp N  &kp U  &kp I     &dead_key &kp P     ,  &kp FSLH ,
-    &kp Z  ,  HRM_A  HRM_S  HRM_D  HRM_F  &kp G   ,   &kp H  HRM_J  HRM_K     HRM_L     HRM_SEMI  ,  &kp FSLH ,
-    &none  ,  &kp Q  &kp X  &kp C  &kp V  &kp B   ,   &kp Y  &kp M  &kp COMMA &kp DOT   &kp P     ,  &none    ,
+    &kp Z  ,  &kp Q  &kp W  &kp E  &kp R  &kp T   ,   &kp N  &kp U  &kp I     &apos   &kp P     ,  &kp FSLH ,
+    &kp Z  ,  HRM_A  HRM_S  HRM_D  HRM_F  &kp G   ,   &kp H  HRM_J  HRM_K     HRM_L   HRM_SEMI  ,  &kp FSLH ,
+    &none  ,  &kp Q  &kp X  &kp C  &kp V  &kp B   ,   &kp Y  &kp M  &kp COMMA &kp DOT &kp P     ,  &none    ,
         LTHUMB_TUCK , LTHUMB_HOME , LTHUMB_REACH  ,   RTHUMB_REACH , RTHUMB_HOME , RTHUMB_TUCK
   )>;
 };
@@ -27,13 +27,8 @@
 / {
   behaviors {
     // Swap out the standard dead key for a one-shot layer to override some of the keys
-    dead_key: dead_key {
-      compatible = "zmk,behavior-mod-morph";
-      #binding-cells = <0>;
-      bindings = <&EZ_SL(ODK_LAYER)>, <&kp O>;
-      mods      = <(MOD_LSFT|MOD_RSFT)>;
-      keep-mods = <(MOD_LSFT|MOD_RSFT)>;
-    };
+    TWO_LEVEL_KEY(apos, &EZ_SL(ODK_LAYER), S_EXCL) // ' ! (1dk)
+    TWO_LEVEL_KEY(em_dash, &odk V, &odk B) // – — (en-dash, em-dash)
 
   #ifdef ENABLE_FANCY_DEAD_KEYS
     #define SHIFT_KEY &EZ_SK(LSHIFT)
@@ -59,10 +54,10 @@
     one_dead_key {
       display-name = "1dk";
       bindings = <SELENIUM_KEYMAP_BINDINGS(
-        &trans  ,  &odk Q  &odk W  &odk E  &odk R  &kp Z   ,   &odk N  &kp Y    &odk I     &odk O   &odk P    ,  &trans ,
-        &trans  ,  &odk A  &odk S  &odk D  &odk F  &kp B   ,   &odk H  &odk J   &odk K     &odk L   &odk SEMI ,  &trans ,
-        &trans  ,  &odk Q  &odk Z  &odk C  &odk V  &trans  ,   &trans  &kp FSLH &odk COMMA &odk DOT &odk P    ,  &trans ,
-            &EZ_SL(ODK_SHIFT_LAYER) , &odk SPACE , &trans  ,   &trans , &odk SPACE , &trans
+        &trans  ,  &odk Q  &odk W  &odk E  &odk R   &kp Z   ,   &odk N  &kp Y    &odk I     &odk O   &odk P    ,  &trans ,
+        &trans  ,  &odk A  &odk S  &odk D  &odk F   &kp B   ,   &odk H  &odk J   &odk K     &odk L   &odk SEMI ,  &trans ,
+        &trans  ,  &odk Q  &odk Z  &odk C  &em_dash &trans  ,   &trans  &kp FSLH &odk COMMA &odk DOT &odk P    ,  &trans ,
+                          SHIFT_KEY , &odk SPACE , &trans  ,   &trans , &odk SPACE , &trans
       )>;
     };
 

--- a/include/aekeynox/selenium.keymap
+++ b/include/aekeynox/selenium.keymap
@@ -110,9 +110,9 @@
     fn_media_layer: fn_media_layer {
       display-name = "FnMedia";
       bindings = <SELENIUM_KEYMAP_BINDINGS(
-        &trans  ,  &kp F1  &kp F2  &kp F3  &kp F4  &none   ,   &none  &kp C_PREV  &kp C_VOL_UP  &kp C_BRI_UP   &kp SLCK      ,  &trans ,
+        &trans  ,  &kp F1  &kp F2  &kp F3  &kp F4  &none   ,   &none  &kp C_NEXT  &kp C_VOL_UP  &kp C_BRI_UP   &kp SLCK      ,  &trans ,
         &trans  ,  &kp F5  &kp F6  &kp F7  &kp F8  &none   ,   &none  H_J C_PP    H_K C_MUTE    H_L C_AL_LOCK  H_SEMI PSCRN  ,  &trans ,
-        &trans  ,  &kp F9  &kp F10 &kp F11 &kp F12 &none   ,   &none  &kp C_NEXT  &kp C_VOL_DN  &kp C_BRI_DN   &kp INS       ,  &trans ,
+        &trans  ,  &kp F9  &kp F10 &kp F11 &kp F12 &none   ,   &none  &kp C_PREV  &kp C_VOL_DN  &kp C_BRI_DN   &kp INS       ,  &trans ,
                            &trans , &trans , &bootloader   ,   &sys_reset , &trans , &studio_unlock
       )>;
     };

--- a/include/aekeynox/selenium.keymap
+++ b/include/aekeynox/selenium.keymap
@@ -113,7 +113,7 @@
         &trans  ,  &kp F1  &kp F2  &kp F3  &kp F4  &none   ,   &none  &kp C_NEXT  &kp C_VOL_UP  &kp C_BRI_UP   &kp SLCK      ,  &trans ,
         &trans  ,  &kp F5  &kp F6  &kp F7  &kp F8  &none   ,   &none  H_J C_PP    H_K C_MUTE    H_L C_AL_LOCK  H_SEMI PSCRN  ,  &trans ,
         &trans  ,  &kp F9  &kp F10 &kp F11 &kp F12 &none   ,   &none  &kp C_PREV  &kp C_VOL_DN  &kp C_BRI_DN   &kp INS       ,  &trans ,
-                           &trans , &trans , &bootloader   ,   &sys_reset , &trans , &studio_unlock
+                           &trans , &bootloader , &trans   ,   &trans , &sys_reset , &studio_unlock
       )>;
     };
 

--- a/include/aekeynox/selenium.keymap
+++ b/include/aekeynox/selenium.keymap
@@ -74,7 +74,7 @@
         &trans  ,  &none    X_CTL_W  &vim_prev &vim_next &none     ,   &kp HOME &kp PG_DN &kp PG_UP &kp END   &kp DEL ,  &trans ,
         &trans  ,  X_ALL    X_SAVE   X_SHTAB   &kp TAB   &none     ,   &kp LEFT &kp DOWN  &kp UP    &kp RIGHT &none   ,  &trans ,
         &trans  ,  X_UNDO   X_CUT    X_COPY    X_PASTE   X_REDO    ,   &none    &none     &none     &none     &none   ,  &trans ,
-            &kp CAPS , &lt FN_MEDIA_LAYER DEL , &mo NUM_ROW_LAYER ,   &trans ,  &mo FN_MEDIA_LAYER , &EZ_LSK(RALT)
+            &kp CAPS , &sc FN_MEDIA_LAYER DEL , &mo NUM_ROW_LAYER ,   &trans ,  &mo FN_MEDIA_LAYER , &EZ_LSK(RALT)
       )>;
     };
 


### PR DESCRIPTION
Various small keymap fixes:
- Reused the same kind of declaration for Ergo‑L (hummingbird) dead key as it’s emulation, added a mod-morph to get the long dash (one of the few missing keys for this layout), and actually use the `SHIFT_KEY` macro.
- Swapped `previous` and `next` on the media layer, as `next` feels more inline with "more", and thus should be on the same row as `volume +` or `brightness +`
- Put the bootloader and sys-reset keys on the home-row, so that they are still accessible when using the keymap in the 2tk flavor.
- Fixed a space-cadet I forgot to change a while back.