### PR TITLE
fix: tap shifted key in `DEAD_KEY_SHIFT` macro

### DIFF
--- a/include/aekeynox/mappings.dtsi
+++ b/include/aekeynox/mappings.dtsi
@@ -26,7 +26,7 @@
     = <&macro_tap key>                                        \
     , <&macro_pause_for_release>                              \
     , <&macro_press &kp LSHIFT>                               \
-    , <&macro_param_1to1 &kp MACRO_PLACEHOLDER>               \
+    , <&macro_tap &macro_param_1to1 &kp MACRO_PLACEHOLDER>    \
     , <&macro_release &kp LSHIFT>                             \
     ;                                                         \
 };


### PR DESCRIPTION
This is a follow up to [this issue](https://github.com/Nuclear-Squid/zmk-keyboard-quacken/issues/62) from the quacken repo (who had the first implementation of Selenium). The fix was to propose a toggle to enable a fancy dead-key behavior I developed for the personal keymap I had at the time, but it has issues (see #30 )

This PR fixes the *now obvious* error in this macro definition, which is that we *press* the shifted key instead of *tapping* it. I’m still going to try and fix the fancy dead-keys, as I believe them to be handy.