### PR TITLE
fix: remove `&macro_pause_for_release` on dead keys

### DIFF
--- a/include/aekeynox/mappings.dtsi
+++ b/include/aekeynox/mappings.dtsi
@@ -10,7 +10,6 @@
   wait-ms = <0>;                                        \
   bindings                                              \
     = <&macro_tap key>                                  \
-    , <&macro_pause_for_release>                        \
     , <&macro_param_1to1 &kp MACRO_PLACEHOLDER>         \
     ;                                                   \
 };
@@ -24,7 +23,6 @@
   wait-ms = <0>;                                              \
   bindings                                                    \
     = <&macro_tap key>                                        \
-    , <&macro_pause_for_release>                              \
     , <&macro_press &kp LSHIFT>                               \
     , <&macro_tap &macro_param_1to1 &kp MACRO_PLACEHOLDER>    \
     , <&macro_release &kp LSHIFT>                             \


### PR DESCRIPTION
This PR aims to fix a timing issue with the current dead-key macros. The macro used to press the wrapped dead key, then wait for the release of the physical key before typing the key passed as argument to the behavior. This lead to timing issues were if you:

- press a dead-key macro (let’s say `&odk W` to type a `ç` in Ergo‑L using the Hummingbird layers)
- tap / press a regular `&kp` (let’s say [A])
- release the dead-key macro

You’ll have the sequence [OAW] (= `àc`) instead of [OWA] (= `ça`).

This issue is fixed by removing the pause-for-release in the macro definition.

(PS: This fix is *not* related to #30 since this tackles the macro-based implementation of a dead key wrapper, not the custom behavior)