### PR TITLE
docs: update dead key documentation following #56

### DIFF
--- a/include/aekeynox/mappings.dtsi
+++ b/include/aekeynox/mappings.dtsi
@@ -2,7 +2,6 @@
 #include <dt-bindings/zmk/keys.h>
 
 // Define a dead layer key
-// note: macro_pause_for_release might be useless
 #define DEAD_KEY(name, key) OMIT_IF_NO_REF name: name { \
   compatible = "zmk,behavior-macro-one-param";          \
   #binding-cells = <1>;                                 \
@@ -15,7 +14,6 @@
 };
 
 // Define a shifted dead layer key
-// note: macro_pause_for_release might be useless
 #define DEAD_KEY_SHIFT(name, key) OMIT_IF_NO_REF name: name { \
   compatible = "zmk,behavior-macro-one-param";                \
   #binding-cells = <1>;                                       \

--- a/include/aekeynox/settings.h
+++ b/include/aekeynox/settings.h
@@ -52,6 +52,8 @@
 // [Experimental]
 // Uncomment the following line for an improved dead key support.
 // This only applies to some Hummingbird keymaps and layout emulations.
+// XXX: Timing issues when nested in a hold-tap are known, see this issue:
+// https://github.com/OneDeadKey/zmk-config-aekeynox/issues/30
 
 // #define ENABLE_FANCY_DEAD_KEYS
 


### PR DESCRIPTION
This is a follow-up to #56, I forgot to update the docs. My bad.