### PR TITLE
fix(ergol-hummingibird): access to odk + numbers

### DIFF
--- a/include/aekeynox/extra_layers/ergol_hummingbird.dtsi
+++ b/include/aekeynox/extra_layers/ergol_hummingbird.dtsi
@@ -65,7 +65,7 @@
         &trans  ,  &odk Q  &odk W  &odk E  &odk R   &kp Z   ,   &odk N  &kp Y    &odk I     &odk O   &odk P    ,  &trans ,
         &trans  ,  &odk A  &odk S  &odk D  &odk F   &kp B   ,   &odk H  &odk J   &odk K     &odk L   &odk SEMI ,  &trans ,
         &trans  ,  &odk Q  &odk Z  &odk C  &em_dash &trans  ,   &trans  &kp FSLH &odk COMMA &odk DOT &odk P    ,  &trans ,
-                           SHIFT_KEY , &odk SPACE , &dknum  ,   &dknum , &odk SPACE , &trans
+                               SHIFT_KEY , &dknum , &trans  ,   &trans , &odk SPACE , &trans
       )>;
     };
 

--- a/include/aekeynox/extra_layers/ergol_hummingbird.dtsi
+++ b/include/aekeynox/extra_layers/ergol_hummingbird.dtsi
@@ -44,6 +44,14 @@
   #endif
     // Same as `odk`, but adds Shift to the specified key
     DEAD_KEY_SHIFT(odks, &kp O)
+
+    dknum: dead_key_numbers {
+      compatible = "zmk,behavior-macro";
+      #binding-cells = <0>;
+      tap-ms = <0>;
+      wait-ms = <0>;
+      bindings = <&kp O &osl NUM_LAYER>;
+    };
   };
 
   // Extra layers defined specifically for this keymap.
@@ -57,7 +65,7 @@
         &trans  ,  &odk Q  &odk W  &odk E  &odk R   &kp Z   ,   &odk N  &kp Y    &odk I     &odk O   &odk P    ,  &trans ,
         &trans  ,  &odk A  &odk S  &odk D  &odk F   &kp B   ,   &odk H  &odk J   &odk K     &odk L   &odk SEMI ,  &trans ,
         &trans  ,  &odk Q  &odk Z  &odk C  &em_dash &trans  ,   &trans  &kp FSLH &odk COMMA &odk DOT &odk P    ,  &trans ,
-                          SHIFT_KEY , &odk SPACE , &trans  ,   &trans , &odk SPACE , &trans
+                           SHIFT_KEY , &odk SPACE , &dknum  ,   &dknum , &odk SPACE , &trans
       )>;
     };
 


### PR DESCRIPTION
Ergo‑L’s symbols located on odk -> numbers weren’t actually accessible in the "hummingbird" keymap, as the dead key is overridden with a one-shot layer and this interaction wasn’t accounted for.

This PR adds a small macro that provides this function.