### PR TITLE
feat: added an opt-in mod_hold on pinky as HRM

### DIFF
--- a/include/aekeynox/hold_taps.dtsi
+++ b/include/aekeynox/hold_taps.dtsi
@@ -43,9 +43,15 @@
 #define H_K &hrm CTL_CMD
 #define H_L &hrm GUI_OPT
 
-#ifdef HRM_SHIFT
+#if defined HRM_SHIFT && defined PINKY_MOD_HOLD
+  #define H_A    &mhhrm LSHIFT
+  #define H_SEMI &mhhrm RSHIFT
+#elif defined HRM_SHIFT
   #define H_A    &hrm LSHIFT
   #define H_SEMI &hrm RSHIFT
+#elif defined PINKY_MOD_HOLD
+  #define H_A    &mhkp 0
+  #define H_SEMI &mhkp 0
 #else
   #define H_A    &kp
   #define H_SEMI &kp
@@ -326,6 +332,29 @@
       bindings = <&kp LA(RIGHT)>, <&kp GRAVE>;
       mods      = <(MOD_LALT|MOD_LGUI)>;
       keep-mods = <(MOD_LALT|MOD_LGUI)>;
+    };
+
+    OMIT_IF_NO_REF mh: raw_mod_hold {
+      compatible = "zmk,behavior-mod-hold";
+      #binding-cells = <2>;
+      binding = <&none>;
+      mods-to-hold = <(MOD_LCTL|MOD_RCTL|MOD_LALT|MOD_RALT|MOD_LGUI|MOD_RGUI)>;
+    };
+
+    OMIT_IF_NO_REF mhkp: hrm_with_raw_mh_on_hold {
+      compatible = "zmk,behavior-hold-tap";
+      #binding-cells = <2>;
+      tapping-term-ms = <TAPPING_TERM>;
+      quick-tap-ms = <QUICK_TAP>;
+      flavor = "tap-preferred";
+      bindings = <&mh>, <&kp>;
+    };
+
+    OMIT_IF_NO_REF mhhrm: hrm_with_held_mods {
+      compatible = "zmk,behavior-mod-hold";
+      #binding-cells = <2>;
+      binding = <&hrm>;
+      mods-to-hold = <(MOD_LCTL|MOD_RCTL|MOD_LALT|MOD_RALT|MOD_LGUI|MOD_RGUI)>;
     };
   };
 };

--- a/include/aekeynox/settings.h
+++ b/include/aekeynox/settings.h
@@ -117,6 +117,13 @@
 
 // #define HRM_SHIFT
 
+// [Experimental]
+// Uncomment the following line to enable a mod-hold behavior when holding
+// a pinky key. Useful for one-handed home row mods, when the modifier and
+// keycode ar on the same key (i.e. Ctrl + D)
+
+// #define PINKY_MOD_HOLD
+
 // Uncomment the following line to swap Space and Backspace.
 // Beware: this increases the typing load of the left thumb.
 


### PR DESCRIPTION
This is an experiment I thought of for a while now, and it’s surprisingly a *lot* more versatile than I originally thought.

Basically, this PR adds a setting to enable a `mod-hold` behavior on the pinky keys. It serves to "lock" any modifier other than Shift for as long as the key is held. Common applications are:
- one-handed shortcuts with HRMs (like Ctrl-E in Ergo‑L)
- combining modifiers with keys on other layers, Ctrl (or Alt) + Tab / Shift + Tab when vim mode is enabled (this could be a replacement for the current mod-hold on left nav, who is pretty specific and doesn’t leave *that* much control to the user)
- combining modifiers on the same thumb with the TT flavor of hold-taps (not sure if people would combine these two options, but it *could* be nice)