### PR TITLE
fix: release dead key with correct timing, fixes #30

### DIFF
--- a/include/aekeynox/settings.h
+++ b/include/aekeynox/settings.h
@@ -52,8 +52,6 @@
 // [Experimental]
 // Uncomment the following line for an improved dead key support.
 // This only applies to some Hummingbird keymaps and layout emulations.
-// XXX: Timing issues when nested in a hold-tap are known, see this issue:
-// https://github.com/OneDeadKey/zmk-config-aekeynox/issues/30
 
 // #define ENABLE_FANCY_DEAD_KEYS
 

--- a/src/behaviors/behavior_dead_key.c
+++ b/src/behaviors/behavior_dead_key.c
@@ -12,7 +12,7 @@
 #include <drivers/behavior.h>
 #include <dt-bindings/zmk/modifiers.h>
 #include <zmk/event_manager.h>
-#include <zmk/events/position_state_changed.h>
+#include <zmk/events/keycode_state_changed.h>
 #include <zmk/hid.h>
 
 LOG_MODULE_DECLARE(zmk, CONFIG_ZMK_LOG_LEVEL);
@@ -89,13 +89,13 @@ static const struct behavior_driver_api dead_key_driver_api = {
     .binding_released = on_dead_key_binding_released,
 };
 
-static int dead_key_position_state_changed_listener(const zmk_event_t *eh);
+static int dead_key_keycode_state_changed_listener(const zmk_event_t *eh);
 
-ZMK_LISTENER(behavior_dead_key, dead_key_position_state_changed_listener);
-ZMK_SUBSCRIPTION(behavior_dead_key, zmk_position_state_changed);
+ZMK_LISTENER(behavior_dead_key, dead_key_keycode_state_changed_listener);
+ZMK_SUBSCRIPTION(behavior_dead_key, zmk_keycode_state_changed);
 
-static int dead_key_position_state_changed_listener(const zmk_event_t *eh) {
-    struct zmk_position_state_changed *ev = as_zmk_position_state_changed(eh);
+static int dead_key_keycode_state_changed_listener(const zmk_event_t *eh) {
+    struct zmk_keycode_state_changed *ev = as_zmk_keycode_state_changed(eh);
     if (ev == NULL || !active_dead_key.is_down) {
         return ZMK_EV_EVENT_BUBBLE;
     }
@@ -113,8 +113,8 @@ static int dead_key_position_state_changed_listener(const zmk_event_t *eh) {
         #endif
     };
 
-    zmk_behavior_invoke_binding(&kp_binding, event, false);
     active_dead_key.is_down = false;
+    zmk_behavior_invoke_binding(&kp_binding, event, false);
 
     return ZMK_EV_EVENT_BUBBLE;
 }


### PR DESCRIPTION
The custom dead key behavior used to fail to release the dead key when it was nested inside a hold-tap (like a `&bsl`). For more info, see #30.

The issue seems to be that in order to release the dead key before sending handling another key press, the behavior would listen to the `position_state_changed` event. This event isn’t triggered when a key is sent to the computer (that would be `keycode_state_changed`), but when a physical key is pressed on the keyboard.

The approximation is usually good enough, but when nested in a hold-tap, the dead-key behavior isn’t invoked right away (as the hold-tap has to resolve first), meaning the `position_state_changed` event is raised *before* the dead-key behavior is invoked, and thus isn’t caught, so the dead-key isn’t released.

I’ve switched the event listener to `keycode_state_changed`, which fixes the issue (along it with being the "correct" event to listen, in regards to what is typed by the keeb). The reason we weren’t listening to this event in the first place was that the keeb would consistently crash when I first tried this implementation. Turns out, I only needed to declare the dead key as released *before* actually releasing it, otherwise the `keycode_state_changed` event raised by this action would be caught by the *same fucking handler* and cause an infinite recursion, halting the keyboard.

Man do I *fucking LOVE* writing async code in bare-metal C ! (I’m mad, but that was kinda fun honestly)