### PR TITLE
fix(emulation): curved appostrophe with Qwerty-Intl + MacOS, closes #48

### DIFF
--- a/include/aekeynox/aliases/qwerty_intl.h
+++ b/include/aekeynox/aliases/qwerty_intl.h
@@ -170,7 +170,11 @@
 // quote signs
 #define C_LSQT  &kp RA(N9)    // ‘
 #define C_RSQT  &kp RA(N0)    // ’
-#define C_APOS  &kp SA(RBKT)    // ’
+#ifdef MACOS
+  #define C_APOS  &kp SA(RBKT)    // ’
+#else
+  #define C_APOS  &kp RA(N0)    // ’
+#endif
 #define C_LGQT  &kp RA(LBKT)  // «
 #define C_RGQT  &kp RA(RBKT)  // »
 #ifdef LINUX

--- a/include/aekeynox/aliases/qwerty_intl.h
+++ b/include/aekeynox/aliases/qwerty_intl.h
@@ -170,7 +170,7 @@
 // quote signs
 #define C_LSQT  &kp RA(N9)    // ‘
 #define C_RSQT  &kp RA(N0)    // ’
-#define C_APOS  &kp RA(N0)    // ’
+#define C_APOS  &kp SA(RBKT)    // ’
 #define C_LGQT  &kp RA(LBKT)  // «
 #define C_RGQT  &kp RA(RBKT)  // »
 #ifdef LINUX


### PR DESCRIPTION
See https://github.com/OneDeadKey/zmk-config-aekeynox/issues/48