### PR TITLE
Add go60 keyboard support

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -140,6 +140,14 @@ include:
     snippet: studio-rpc-usb-uart
     cmake-args: -DCONFIG_ZMK_STUDIO=y
 
+  # Go60
+  - board: go60_lh
+    artifact-name: go60_left
+    snippet: studio-rpc-usb-uart
+  - board: go60_rh
+    artifact-name: go60_right
+    snippet: studio-rpc-usb-uart
+
   ###
   # Resets
   ##
@@ -153,3 +161,4 @@ include:
   - board: nice_nano@2//zmk
     shield: settings_reset
     artifact-name: nice_nano_v2_settings_reset
+

--- a/config/go60.keymap
+++ b/config/go60.keymap
@@ -1,0 +1,12 @@
+#define SELENIUM_KEYMAP_BINDINGS(LOUT1,  LROW1,  RROW1,  ROUT1, \
+                                 LOUT2,  LROW2,  RROW2,  ROUT2, \
+                                 LOUT3,  LROW3,  RROW3,  ROUT3, \
+                                 LT1, LT2, LT3,  RT3, RT2, RT1) \
+    &kp EQUAL &kp N1 &kp N2 &kp N3 &kp N4 &kp N5 &kp N6 &kp N7 &kp N8 &kp N9 &kp N0 &kp MINUS \
+    LOUT1     LROW1                                                          RROW1  ROUT1     \
+    LOUT2     LROW2                                                          RROW2  ROUT2     \
+    LOUT3     LROW3                                                          RROW3  ROUT3     \
+                     &none  &none  &none                &none  &none  &none                   \
+                                LT1  LT2  LT3      RT3  RT2  RT1
+
+#include <aekeynox/selenium.keymap>

--- a/config/west.yml
+++ b/config/west.yml
@@ -8,6 +8,8 @@ manifest:
       url-base: https://github.com/Nuclear-Squid
     - name: raeedcho
       url-base: https://github.com/raeedcho
+    - name: rloutier
+      url-base: https://github.com/rloutier
   projects:
     - name: zmk
       remote: zmkfirmware
@@ -24,7 +26,8 @@ manifest:
     - name: temper-zmk-config
       remote: raeedcho
       revision: main
-
-
+    - name: zmk-config-go60
+      remote: rloutier
+      revision: main
   self:
     path: config


### PR DESCRIPTION
Tested OK with default aekeynox configuration, on a (Windows) QWERTY host.