### PR TITLE
chore(deps): bump zmk’s version, fixes #55

### DIFF
--- a/config/west.yml
+++ b/config/west.yml
@@ -15,6 +15,7 @@ manifest:
       remote: zmkfirmware
       # Pin ZMK to the latest board fix of the `main` branch on 2026-06-13.
       # https://github.com/Nuclear-Squid/zmk-keyboard-quacken/pull/49#issuecomment-4153385353
+      # https://github.com/OneDeadKey/zmk-config-aekeynox/pull/67
       revision: 9917e2f1371d5bb051bf8eb782c1297db41d742b
       import: app/west.yml
     - name: zmk-keyboard-quacken

--- a/config/west.yml
+++ b/config/west.yml
@@ -13,9 +13,9 @@ manifest:
   projects:
     - name: zmk
       remote: zmkfirmware
-      # Pin ZMK to the tip of the `main` branch on 2026-03-30.
+      # Pin ZMK to the latest board fix of the `main` branch on 2026-06-13.
       # https://github.com/Nuclear-Squid/zmk-keyboard-quacken/pull/49#issuecomment-4153385353
-      revision: c62da0e16646d10240ba29191bdbcb5611b3a1af
+      revision: 9917e2f1371d5bb051bf8eb782c1297db41d742b
       import: app/west.yml
     - name: zmk-keyboard-quacken
       remote: NuclearSquid


### PR DESCRIPTION
The currently pinned version of ZMK fails to build for a handful of boards, including the XIAO-RP2040 and the OLKB Plank. This PR updates the pin to the commit that fixes the Plank (which includes the fixes for the XIAO-RP2040). To my knowledge, no other significant changes to the code base have been made between the old pin and the new one and is (at the time of writing) the most recent code change (changes to the docs have been made later, but they don’t really impact us).