### PR TITLE
fix: tie Shift to the sticky mod in AltGr-Shift bind, fixes #66

### DIFF
--- a/include/aekeynox/hold_taps.dtsi
+++ b/include/aekeynox/hold_taps.dtsi
@@ -266,9 +266,8 @@
     OMIT_IF_NO_REF sym_shift_altgr_inner: sym_shift_altgr_inner {
       compatible = "zmk,behavior-mod-morph";
       #binding-cells = <0>;
-      bindings = <&EZ_SL(SYMBOLS_LAYER)>, <&EZ_SK(RALT)>;
-      mods      = <(MOD_LSFT|MOD_RSFT)>;
-      keep-mods = <(MOD_LSFT|MOD_RSFT)>;
+      bindings = <&EZ_SL(SYMBOLS_LAYER)>, <&EZ_SK(RS(RALT))>;
+      mods = <(MOD_LSFT|MOD_RSFT)>;
     };
 
     // go to base layer and press mod


### PR DESCRIPTION
Currently, when using the AltGr-Shift bind, the AltGr mod is sticky while the Shift mod isn’t, as the one-shot Shift gets consumed by the mod-morph but not prolonged for the entire duration of the new sticky key.

This PR fixes this issue by switching things around. The mod-morph now fully consumes the Shift key without applying it to the binding, but the sticky AltGr is now a real sticky AltGr Shift.