### PR TITLE
Fix minor mistakes on keymaps

### DIFF
--- a/include/aekeynox/aliases/azerty.h
+++ b/include/aekeynox/aliases/azerty.h
@@ -157,7 +157,7 @@
   #define  C_OE &digraph O E
   #define SC_OE &digraph LS(O) LS(E)
   #define  C_AE &digraph Q E
-  #define SC_AE &digraph LS(O) LS(E)
+  #define SC_AE &digraph LS(Q) LS(E)
   #define  C_SZ &digraph S S
 #endif
 #if defined LINUX || defined MACOS

--- a/include/aekeynox/emulations/dvorak.dtsi
+++ b/include/aekeynox/emulations/dvorak.dtsi
@@ -1,9 +1,9 @@
 &base_layer {
   display-name = "Base";
   bindings = <SELENIUM_KEYMAP_BINDINGS(
-    &none  ,  &kp SQT  &kp COMMA &kp DOT &kp P  &kp Y   ,   &kp F  &kp G  &kp C  &kp R  &kp L     ,  &none ,
-    &none  ,  H_A A    H_S O     H_D E   H_F U  &kp I   ,   &kp D  H_J H  H_K T  H_L N  H_SEMI S  ,  &none ,
-    &none  ,  &kp SEMI &kp Q     &kp J   &kp K  &kp X   ,   &kp B  &kp M  &kp W  &kp V  &kp Z     ,  &none ,
+    &kp TAB    ,  &kp SQT  &kp COMMA &kp DOT &kp P  &kp Y   ,   &kp F  &kp G  &kp C  &kp R  &kp L     ,  &kp BACKSPACE ,
+    &kp ESCAPE ,  H_A A    H_S O     H_D E   H_F U  &kp I   ,   &kp D  H_J H  H_K T  H_L N  H_SEMI S  ,  &kp ENTER     ,
+    &kp LSHIFT ,  &kp SEMI &kp Q     &kp J   &kp K  &kp X   ,   &kp B  &kp M  &kp W  &kp V  &kp Z     ,  &kp RSHIFT    ,
              LTHUMB_TUCK , LTHUMB_HOME , LTHUMB_REACH   ,   RTHUMB_REACH , RTHUMB_HOME , RTHUMB_TUCK
   )>;
 };

--- a/include/aekeynox/emulations/ergol.dtsi
+++ b/include/aekeynox/emulations/ergol.dtsi
@@ -20,9 +20,9 @@
   &base_layer {
     display-name = "Base";
     bindings = <SELENIUM_KEYMAP_BINDINGS(
-      &none  ,  &kp A  &kp C  &kp O  &kp P  &kp Z   ,   &kp J  &kp SEMI &kp D  &apos  &kp Y     ,  &none ,
-      &none  ,  H_A Q  H_S S  H_D E  H_F N  &kp F   ,   &kp L  H_J R    H_K T  H_L I  H_SEMI U  ,  &none ,
-      &none  ,  &kp W  &kp X  &dash  &kp V  &kp B   ,   &dot   &kp H    &kp G  &comma &kp K     ,  &none ,
+      &kp TAB    ,  &kp A  &kp C  &kp O  &kp P  &kp Z   ,   &kp J  &kp SEMI &kp D  &apos  &kp Y     ,  &kp BACKSPACE ,
+      &kp ESCAPE ,  H_A Q  H_S S  H_D E  H_F N  &kp F   ,   &kp L  H_J R    H_K T  H_L I  H_SEMI U  ,  &kp ENTER     ,
+      &kp LSHIFT ,  &kp W  &kp X  &dash  &kp V  &kp B   ,   &dot   &kp H    &kp G  &comma &kp K     ,  &kp RSHIFT    ,
          LTHUMB_TUCK , LTHUMB_HOME , LTHUMB_REACH   ,   RTHUMB_REACH , RTHUMB_HOME , RTHUMB_TUCK
     )>;
   };
@@ -54,9 +54,9 @@
 &num_row_layer {
   display-name = "NumRow";
   bindings = <SELENIUM_KEYMAP_BINDINGS(
-    &trans  ,  C_EURO  C_LGQT  C_RGQT  S_DLLR  S_PRCNT  ,   S_CARET S_AMPS  S_STAR  S_LPAR  S_RPAR  ,  &trans ,
-    &trans  ,  S_N1    S_N2    S_N3    S_N4    S_N5     ,   S_N6    S_N7    S_N8    S_N9    S_N0    ,  &trans ,
-    &trans  ,  C_LODQT C_LDQT  C_RDQT  C_CENT  C_DEG    ,   S_MINUS S_COMMA S_DOT   S_COLON S_FSLH  ,  &trans ,
+    &kp TAB    ,  C_EURO  C_LGQT  C_RGQT  S_DLLR  S_PRCNT  ,   S_CARET S_AMPS  S_STAR  S_LPAR  S_RPAR  ,  &kp BACKSPACE ,
+    &kp ESCAPE ,  S_N1    S_N2    S_N3    S_N4    S_N5     ,   S_N6    S_N7    S_N8    S_N9    S_N0    ,  &kp ENTER     ,
+    &kp LSHIFT ,  C_LODQT C_LDQT  C_RDQT  C_CENT  C_DEG    ,   S_MINUS S_COMMA S_DOT   S_COLON S_FSLH  ,  &kp RSHIFT    ,
                              &trans , C_NBSP , &trans   ,   &trans , C_NBSP , &trans
   )>;
 };

--- a/include/aekeynox/emulations/qwerty_lafayette.dtsi
+++ b/include/aekeynox/emulations/qwerty_lafayette.dtsi
@@ -20,9 +20,9 @@
   &base_layer {
     display-name = "Base";
     bindings = <SELENIUM_KEYMAP_BINDINGS(
-      &none  ,  &kp A  &kp Z  &kp E  &kp R  &kp T   ,   &kp Y  &kp U    &kp I  &kp O  &kp P   ,  &none ,
-      &none  ,  H_A Q  H_S S  H_D D  H_F F  &kp G   ,   &kp H  H_J J    H_K K  H_L L  &apos   ,  &none ,
-      &none  ,  &kp W  &kp X  &kp C  &kp V  &kp B   ,   &kp N  &kp SEMI &comma &dot   &slash  ,  &none ,
+      &kp TAB    ,  &kp A  &kp Z  &kp E  &kp R  &kp T   ,   &kp Y  &kp U    &kp I  &kp O  &kp P   ,  &kp BACKSPACE ,
+      &kp ESCAPE ,  H_A Q  H_S S  H_D D  H_F F  &kp G   ,   &kp H  H_J J    H_K K  H_L L  &apos   ,  &kp ENTER     ,
+      &kp LSHIFT ,  &kp W  &kp X  &kp C  &kp V  &kp B   ,   &kp N  &kp SEMI &comma &dot   &slash  ,  &kp RSHIFT    ,
          LTHUMB_TUCK , LTHUMB_HOME , LTHUMB_REACH   ,   RTHUMB_REACH , RTHUMB_HOME , RTHUMB_TUCK
     )>;
   };
@@ -33,9 +33,9 @@
   &base_layer {
     display-name = "Base";
     bindings = <SELENIUM_KEYMAP_BINDINGS(
-      &none  ,  &kp Q  &kp W  &kp E  &kp R  &kp T   ,   &kp Y  &kp U  &kp I  &kp O  &kp P     ,  &none  ,
-      &none  ,  H_A A  H_S S  H_D D  H_F F  &kp G   ,   &kp H  H_J J  H_K K  H_L L  &apos     ,  &none  ,
-      &none  ,  &kp Z  &kp X  &kp C  &kp V  &kp B   ,   &kp N  &kp M  &comma &dot   &kp FSLH  ,  &none  ,
+      &kp TAB    ,  &kp Q  &kp W  &kp E  &kp R  &kp T   ,   &kp Y  &kp U  &kp I  &kp O  &kp P     ,  &kp BACKSPACE ,
+      &kp ESCAPE ,  H_A A  H_S S  H_D D  H_F F  &kp G   ,   &kp H  H_J J  H_K K  H_L L  &apos     ,  &kp ENTER     ,
+      &kp LSHIFT ,  &kp Z  &kp X  &kp C  &kp V  &kp B   ,   &kp N  &kp M  &comma &dot   &kp FSLH  ,  &kp RSHIFT    ,
          LTHUMB_TUCK , LTHUMB_HOME , LTHUMB_REACH   ,   RTHUMB_REACH , RTHUMB_HOME , RTHUMB_TUCK
     )>;
   };


### PR DESCRIPTION
- Fix incorrect AE digraph without alt‐codes in Azerty aliases
- Fix `&none` on outer columns for emulation keymaps