### PR TITLE
Add ability to disable HRM with emulation active

### DIFF
--- a/include/aekeynox/aliases/azerty.h
+++ b/include/aekeynox/aliases/azerty.h
@@ -157,7 +157,7 @@
   #define  C_OE &digraph O E
   #define SC_OE &digraph LS(O) LS(E)
   #define  C_AE &digraph Q E
-  #define SC_AE &digraph LS(O) LS(E)
+  #define SC_AE &digraph LS(Q) LS(E)
   #define  C_SZ &digraph S S
 #endif
 #if defined LINUX || defined MACOS

--- a/include/aekeynox/emulations/dvorak.dtsi
+++ b/include/aekeynox/emulations/dvorak.dtsi
@@ -1,9 +1,9 @@
 &base_layer {
   display-name = "Base";
   bindings = <SELENIUM_KEYMAP_BINDINGS(
-    &none  ,  &kp SQT  &kp COMMA &kp DOT &kp P  &kp Y   ,   &kp F  &kp G  &kp C  &kp R  &kp L     ,  &none ,
-    &none  ,  H_A A    H_S O     H_D E   H_F U  &kp I   ,   &kp D  H_J H  H_K T  H_L N  H_SEMI S  ,  &none ,
-    &none  ,  &kp SEMI &kp Q     &kp J   &kp K  &kp X   ,   &kp B  &kp M  &kp W  &kp V  &kp Z     ,  &none ,
+    &kp TAB    ,  &kp SQT  &kp COMMA &kp DOT &kp P  &kp Y   ,   &kp F  &kp G  &kp C  &kp R  &kp L     ,  &kp BACKSPACE ,
+    &kp ESCAPE ,  H_A A    H_S O     H_D E   H_F U  &kp I   ,   &kp D  H_J H  H_K T  H_L N  H_SEMI S  ,  &kp ENTER     ,
+    &kp LSHIFT ,  &kp SEMI &kp Q     &kp J   &kp K  &kp X   ,   &kp B  &kp M  &kp W  &kp V  &kp Z     ,  &kp RSHIFT    ,
              LTHUMB_TUCK , LTHUMB_HOME , LTHUMB_REACH   ,   RTHUMB_REACH , RTHUMB_HOME , RTHUMB_TUCK
   )>;
 };

--- a/include/aekeynox/emulations/dvorak.dtsi
+++ b/include/aekeynox/emulations/dvorak.dtsi
@@ -1,8 +1,28 @@
+#if defined HT_HOME_ROW_MODS || defined HT_TWO_THUMB_KEYS
+  #define HRM_A    H_A A
+  #define HRM_S    H_S O
+  #define HRM_D    H_D E
+  #define HRM_F    H_F U
+  #define HRM_J    H_J H
+  #define HRM_K    H_K T
+  #define HRM_L    H_L N
+  #define HRM_SEMI H_SEMI S
+#else
+  #define HRM_A    &kp S
+  #define HRM_S    &kp O
+  #define HRM_D    &kp E
+  #define HRM_F    &kp U
+  #define HRM_J    &kp H
+  #define HRM_K    &kp T
+  #define HRM_L    &kp N
+  #define HRM_SEMI &kp S
+#endif
+
 &base_layer {
   display-name = "Base";
   bindings = <SELENIUM_KEYMAP_BINDINGS(
     &kp TAB    ,  &kp SQT  &kp COMMA &kp DOT &kp P  &kp Y   ,   &kp F  &kp G  &kp C  &kp R  &kp L     ,  &kp BACKSPACE ,
-    &kp ESCAPE ,  H_A A    H_S O     H_D E   H_F U  &kp I   ,   &kp D  H_J H  H_K T  H_L N  H_SEMI S  ,  &kp ENTER     ,
+    &kp ESCAPE ,  HRM_A    HRM_S     HRM_D   HRM_F  &kp I   ,   &kp D  HRM_J  HRM_K  HRM_L  HRM_SEMI  ,  &kp ENTER     ,
     &kp LSHIFT ,  &kp SEMI &kp Q     &kp J   &kp K  &kp X   ,   &kp B  &kp M  &kp W  &kp V  &kp Z     ,  &kp RSHIFT    ,
              LTHUMB_TUCK , LTHUMB_HOME , LTHUMB_REACH   ,   RTHUMB_REACH , RTHUMB_HOME , RTHUMB_TUCK
   )>;

--- a/include/aekeynox/emulations/dvorak.dtsi
+++ b/include/aekeynox/emulations/dvorak.dtsi
@@ -1,28 +1,28 @@
 #if defined HT_HOME_ROW_MODS || defined HT_TWO_THUMB_KEYS
   #define HRM_A    H_A A
-  #define HRM_S    H_S O
-  #define HRM_D    H_D E
-  #define HRM_F    H_F U
-  #define HRM_J    H_J H
-  #define HRM_K    H_K T
-  #define HRM_L    H_L N
-  #define HRM_SEMI H_SEMI S
+  #define HRM_O    H_S O
+  #define HRM_E    H_D E
+  #define HRM_U    H_F U
+  #define HRM_H    H_J H
+  #define HRM_T    H_K T
+  #define HRM_N    H_L N
+  #define HRM_S    H_SEMI S
 #else
   #define HRM_A    &kp A
-  #define HRM_S    &kp O
-  #define HRM_D    &kp E
-  #define HRM_F    &kp U
-  #define HRM_J    &kp H
-  #define HRM_K    &kp T
-  #define HRM_L    &kp N
-  #define HRM_SEMI &kp S
+  #define HRM_O    &kp O
+  #define HRM_E    &kp E
+  #define HRM_U    &kp U
+  #define HRM_H    &kp H
+  #define HRM_T    &kp T
+  #define HRM_N    &kp N
+  #define HRM_S    &kp S
 #endif
 
 &base_layer {
   display-name = "Base";
   bindings = <SELENIUM_KEYMAP_BINDINGS(
     &kp TAB    ,  &kp SQT  &kp COMMA &kp DOT &kp P  &kp Y   ,   &kp F  &kp G  &kp C  &kp R  &kp L     ,  &kp BACKSPACE ,
-    &kp ESCAPE ,  HRM_A    HRM_S     HRM_D   HRM_F  &kp I   ,   &kp D  HRM_J  HRM_K  HRM_L  HRM_SEMI  ,  &kp ENTER     ,
+    &kp ESCAPE ,  HRM_A    HRM_O     HRM_E   HRM_U  &kp I   ,   &kp D  HRM_H  HRM_T  HRM_N  HRM_S     ,  &kp ENTER     ,
     &kp LSHIFT ,  &kp SEMI &kp Q     &kp J   &kp K  &kp X   ,   &kp B  &kp M  &kp W  &kp V  &kp Z     ,  &kp RSHIFT    ,
              LTHUMB_TUCK , LTHUMB_HOME , LTHUMB_REACH   ,   RTHUMB_REACH , RTHUMB_HOME , RTHUMB_TUCK
   )>;

--- a/include/aekeynox/emulations/dvorak.dtsi
+++ b/include/aekeynox/emulations/dvorak.dtsi
@@ -8,7 +8,7 @@
   #define HRM_L    H_L N
   #define HRM_SEMI H_SEMI S
 #else
-  #define HRM_A    &kp S
+  #define HRM_A    &kp A
   #define HRM_S    &kp O
   #define HRM_D    &kp E
   #define HRM_F    &kp U

--- a/include/aekeynox/emulations/ergol.dtsi
+++ b/include/aekeynox/emulations/ergol.dtsi
@@ -17,11 +17,31 @@
 
 #ifdef KB_LAYOUT_AZERTY
 
+  #if defined HT_HOME_ROW_MODS || defined HT_TWO_THUMB_KEYS
+    #define HRM_A    H_A Q
+    #define HRM_S    H_S S
+    #define HRM_D    H_D E
+    #define HRM_F    H_F N
+    #define HRM_J    H_J R
+    #define HRM_K    H_K T
+    #define HRM_L    H_L I
+    #define HRM_SEMI H_SEMI U
+  #else
+    #define HRM_A    &kp Q
+    #define HRM_S    &kp S
+    #define HRM_D    &kp E
+    #define HRM_F    &kp N
+    #define HRM_J    &kp R
+    #define HRM_K    &kp T
+    #define HRM_L    &kp I
+    #define HRM_SEMI &kp U
+  #endif
+
   &base_layer {
     display-name = "Base";
     bindings = <SELENIUM_KEYMAP_BINDINGS(
       &kp TAB    ,  &kp A  &kp C  &kp O  &kp P  &kp Z   ,   &kp J  &kp SEMI &kp D  &apos  &kp Y     ,  &kp BACKSPACE ,
-      &kp ESCAPE ,  H_A Q  H_S S  H_D E  H_F N  &kp F   ,   &kp L  H_J R    H_K T  H_L I  H_SEMI U  ,  &kp ENTER     ,
+      &kp ESCAPE ,  HRM_A  HRM_S  HRM_D  HRM_F  &kp F   ,   &kp L  HRM_J    HRM_K  HRM_L  HRM_SEMI  ,  &kp ENTER     ,
       &kp LSHIFT ,  &kp W  &kp X  &dash  &kp V  &kp B   ,   &dot   &kp H    &kp G  &comma &kp K     ,  &kp RSHIFT    ,
          LTHUMB_TUCK , LTHUMB_HOME , LTHUMB_REACH   ,   RTHUMB_REACH , RTHUMB_HOME , RTHUMB_TUCK
     )>;
@@ -29,12 +49,31 @@
   #define K_DIA &kp LBRC // diaeresis
 
 #elif defined KB_LAYOUT_QWERTY_INTL
+  #if defined HT_HOME_ROW_MODS || defined HT_TWO_THUMB_KEYS
+    #define HRM_A    H_A A
+    #define HRM_S    H_S S
+    #define HRM_D    H_D E
+    #define HRM_F    H_F N
+    #define HRM_J    H_J R
+    #define HRM_K    H_K T
+    #define HRM_L    H_L I
+    #define HRM_SEMI H_SEMI U
+  #else
+    #define HRM_A    &kp A
+    #define HRM_S    &kp S
+    #define HRM_D    &kp E
+    #define HRM_F    &kp N
+    #define HRM_J    &kp R
+    #define HRM_K    &kp T
+    #define HRM_L    &kp I
+    #define HRM_SEMI &kp U
+  #endif
 
   &base_layer {
     display-name = "Base";
     bindings = <SELENIUM_KEYMAP_BINDINGS(
       &none  ,  &kp Q  &kp C  &kp O  &kp P  &kp W   ,   &kp J  &kp M  &kp D  &apos  &kp Y     ,  &none ,
-      &none  ,  H_A A  H_S S  H_D E  H_F N  &kp F   ,   &kp L  H_J R  H_K T  H_L I  H_SEMI U  ,  &none ,
+      &none  ,  HRM_A  HRM_S  HRM_D  HRM_F  &kp F   ,   &kp L  HRM_J  HRM_K  HRM_L  HRM_SEMI  ,  &none ,
       &none  ,  &kp Z  &kp X  &dash  &kp V  &kp B   ,   &dot   &kp H  &kp G  &comma &kp K     ,  &none ,
          LTHUMB_TUCK , LTHUMB_HOME , LTHUMB_REACH   ,   RTHUMB_REACH , RTHUMB_HOME , RTHUMB_TUCK
     )>;

--- a/include/aekeynox/emulations/ergol.dtsi
+++ b/include/aekeynox/emulations/ergol.dtsi
@@ -20,9 +20,9 @@
   &base_layer {
     display-name = "Base";
     bindings = <SELENIUM_KEYMAP_BINDINGS(
-      &none  ,  &kp A  &kp C  &kp O  &kp P  &kp Z   ,   &kp J  &kp SEMI &kp D  &apos  &kp Y     ,  &none ,
-      &none  ,  H_A Q  H_S S  H_D E  H_F N  &kp F   ,   &kp L  H_J R    H_K T  H_L I  H_SEMI U  ,  &none ,
-      &none  ,  &kp W  &kp X  &dash  &kp V  &kp B   ,   &dot   &kp H    &kp G  &comma &kp K     ,  &none ,
+      &kp TAB    ,  &kp A  &kp C  &kp O  &kp P  &kp Z   ,   &kp J  &kp SEMI &kp D  &apos  &kp Y     ,  &kp BACKSPACE ,
+      &kp ESCAPE ,  H_A Q  H_S S  H_D E  H_F N  &kp F   ,   &kp L  H_J R    H_K T  H_L I  H_SEMI U  ,  &kp ENTER     ,
+      &kp LSHIFT ,  &kp W  &kp X  &dash  &kp V  &kp B   ,   &dot   &kp H    &kp G  &comma &kp K     ,  &kp RSHIFT    ,
          LTHUMB_TUCK , LTHUMB_HOME , LTHUMB_REACH   ,   RTHUMB_REACH , RTHUMB_HOME , RTHUMB_TUCK
     )>;
   };
@@ -54,9 +54,9 @@
 &num_row_layer {
   display-name = "NumRow";
   bindings = <SELENIUM_KEYMAP_BINDINGS(
-    &trans  ,  C_EURO  C_LGQT  C_RGQT  S_DLLR  S_PRCNT  ,   S_CARET S_AMPS  S_STAR  S_LPAR  S_RPAR  ,  &trans ,
-    &trans  ,  S_N1    S_N2    S_N3    S_N4    S_N5     ,   S_N6    S_N7    S_N8    S_N9    S_N0    ,  &trans ,
-    &trans  ,  C_LODQT C_LDQT  C_RDQT  C_CENT  C_DEG    ,   S_MINUS S_COMMA S_DOT   S_COLON S_FSLH  ,  &trans ,
+    &kp TAB    ,  C_EURO  C_LGQT  C_RGQT  S_DLLR  S_PRCNT  ,   S_CARET S_AMPS  S_STAR  S_LPAR  S_RPAR  ,  &kp BACKSPACE ,
+    &kp ESCAPE ,  S_N1    S_N2    S_N3    S_N4    S_N5     ,   S_N6    S_N7    S_N8    S_N9    S_N0    ,  &kp ENTER     ,
+    &kp LSHIFT ,  C_LODQT C_LDQT  C_RDQT  C_CENT  C_DEG    ,   S_MINUS S_COMMA S_DOT   S_COLON S_FSLH  ,  &kp RSHIFT    ,
                              &trans , C_NBSP , &trans   ,   &trans , C_NBSP , &trans
   )>;
 };

--- a/include/aekeynox/emulations/ergol.dtsi
+++ b/include/aekeynox/emulations/ergol.dtsi
@@ -18,30 +18,30 @@
 #ifdef KB_LAYOUT_AZERTY
 
   #if defined HT_HOME_ROW_MODS || defined HT_TWO_THUMB_KEYS
-    #define HRM_A    H_A Q
+    #define HRM_Q    H_A Q
     #define HRM_S    H_S S
-    #define HRM_D    H_D E
-    #define HRM_F    H_F N
-    #define HRM_J    H_J R
-    #define HRM_K    H_K T
-    #define HRM_L    H_L I
-    #define HRM_SEMI H_SEMI U
+    #define HRM_E    H_D E
+    #define HRM_N    H_F N
+    #define HRM_R    H_J R
+    #define HRM_T    H_K T
+    #define HRM_I    H_L I
+    #define HRM_U    H_SEMI U
   #else
-    #define HRM_A    &kp Q
+    #define HRM_Q    &kp Q
     #define HRM_S    &kp S
-    #define HRM_D    &kp E
-    #define HRM_F    &kp N
-    #define HRM_J    &kp R
-    #define HRM_K    &kp T
-    #define HRM_L    &kp I
-    #define HRM_SEMI &kp U
+    #define HRM_E    &kp E
+    #define HRM_N    &kp N
+    #define HRM_R    &kp R
+    #define HRM_T    &kp T
+    #define HRM_I    &kp I
+    #define HRM_U    &kp U
   #endif
 
   &base_layer {
     display-name = "Base";
     bindings = <SELENIUM_KEYMAP_BINDINGS(
       &kp TAB    ,  &kp A  &kp C  &kp O  &kp P  &kp Z   ,   &kp J  &kp SEMI &kp D  &apos  &kp Y     ,  &kp BACKSPACE ,
-      &kp ESCAPE ,  HRM_A  HRM_S  HRM_D  HRM_F  &kp F   ,   &kp L  HRM_J    HRM_K  HRM_L  HRM_SEMI  ,  &kp ENTER     ,
+      &kp ESCAPE ,  HRM_Q  HRM_S  HRM_E  HRM_N  &kp F   ,   &kp L  HRM_R    HRM_T  HRM_I  HRM_U     ,  &kp ENTER     ,
       &kp LSHIFT ,  &kp W  &kp X  &dash  &kp V  &kp B   ,   &dot   &kp H    &kp G  &comma &kp K     ,  &kp RSHIFT    ,
          LTHUMB_TUCK , LTHUMB_HOME , LTHUMB_REACH   ,   RTHUMB_REACH , RTHUMB_HOME , RTHUMB_TUCK
     )>;
@@ -52,28 +52,28 @@
   #if defined HT_HOME_ROW_MODS || defined HT_TWO_THUMB_KEYS
     #define HRM_A    H_A A
     #define HRM_S    H_S S
-    #define HRM_D    H_D E
-    #define HRM_F    H_F N
-    #define HRM_J    H_J R
-    #define HRM_K    H_K T
-    #define HRM_L    H_L I
-    #define HRM_SEMI H_SEMI U
+    #define HRM_E    H_D E
+    #define HRM_N    H_F N
+    #define HRM_R    H_J R
+    #define HRM_T    H_K T
+    #define HRM_I    H_L I
+    #define HRM_U    H_SEMI U
   #else
     #define HRM_A    &kp A
     #define HRM_S    &kp S
-    #define HRM_D    &kp E
-    #define HRM_F    &kp N
-    #define HRM_J    &kp R
-    #define HRM_K    &kp T
-    #define HRM_L    &kp I
-    #define HRM_SEMI &kp U
+    #define HRM_E    &kp E
+    #define HRM_N    &kp N
+    #define HRM_R    &kp R
+    #define HRM_T    &kp T
+    #define HRM_I    &kp I
+    #define HRM_U    &kp U
   #endif
 
   &base_layer {
     display-name = "Base";
     bindings = <SELENIUM_KEYMAP_BINDINGS(
       &none  ,  &kp Q  &kp C  &kp O  &kp P  &kp W   ,   &kp J  &kp M  &kp D  &apos  &kp Y     ,  &none ,
-      &none  ,  HRM_A  HRM_S  HRM_D  HRM_F  &kp F   ,   &kp L  HRM_J  HRM_K  HRM_L  HRM_SEMI  ,  &none ,
+      &none  ,  HRM_A  HRM_S  HRM_E  HRM_N  &kp F   ,   &kp L  HRM_R  HRM_T  HRM_I  HRM_U     ,  &none ,
       &none  ,  &kp Z  &kp X  &dash  &kp V  &kp B   ,   &dot   &kp H  &kp G  &comma &kp K     ,  &none ,
          LTHUMB_TUCK , LTHUMB_HOME , LTHUMB_REACH   ,   RTHUMB_REACH , RTHUMB_HOME , RTHUMB_TUCK
     )>;

--- a/include/aekeynox/emulations/qwerty_lafayette.dtsi
+++ b/include/aekeynox/emulations/qwerty_lafayette.dtsi
@@ -20,9 +20,9 @@
   &base_layer {
     display-name = "Base";
     bindings = <SELENIUM_KEYMAP_BINDINGS(
-      &none  ,  &kp A  &kp Z  &kp E  &kp R  &kp T   ,   &kp Y  &kp U    &kp I  &kp O  &kp P   ,  &none ,
-      &none  ,  H_A Q  H_S S  H_D D  H_F F  &kp G   ,   &kp H  H_J J    H_K K  H_L L  &apos   ,  &none ,
-      &none  ,  &kp W  &kp X  &kp C  &kp V  &kp B   ,   &kp N  &kp SEMI &comma &dot   &slash  ,  &none ,
+      &kp TAB    ,  &kp A  &kp Z  &kp E  &kp R  &kp T   ,   &kp Y  &kp U    &kp I  &kp O  &kp P   ,  &kp BACKSPACE ,
+      &kp ESCAPE ,  H_A Q  H_S S  H_D D  H_F F  &kp G   ,   &kp H  H_J J    H_K K  H_L L  &apos   ,  &kp ENTER     ,
+      &kp LSHIFT ,  &kp W  &kp X  &kp C  &kp V  &kp B   ,   &kp N  &kp SEMI &comma &dot   &slash  ,  &kp RSHIFT    ,
          LTHUMB_TUCK , LTHUMB_HOME , LTHUMB_REACH   ,   RTHUMB_REACH , RTHUMB_HOME , RTHUMB_TUCK
     )>;
   };
@@ -33,9 +33,9 @@
   &base_layer {
     display-name = "Base";
     bindings = <SELENIUM_KEYMAP_BINDINGS(
-      &none  ,  &kp Q  &kp W  &kp E  &kp R  &kp T   ,   &kp Y  &kp U  &kp I  &kp O  &kp P     ,  &none  ,
-      &none  ,  H_A A  H_S S  H_D D  H_F F  &kp G   ,   &kp H  H_J J  H_K K  H_L L  &apos     ,  &none  ,
-      &none  ,  &kp Z  &kp X  &kp C  &kp V  &kp B   ,   &kp N  &kp M  &comma &dot   &kp FSLH  ,  &none  ,
+      &kp TAB    ,  &kp Q  &kp W  &kp E  &kp R  &kp T   ,   &kp Y  &kp U  &kp I  &kp O  &kp P     ,  &kp BACKSPACE ,
+      &kp ESCAPE ,  H_A A  H_S S  H_D D  H_F F  &kp G   ,   &kp H  H_J J  H_K K  H_L L  &apos     ,  &kp ENTER     ,
+      &kp LSHIFT ,  &kp Z  &kp X  &kp C  &kp V  &kp B   ,   &kp N  &kp M  &comma &dot   &kp FSLH  ,  &kp RSHIFT    ,
          LTHUMB_TUCK , LTHUMB_HOME , LTHUMB_REACH   ,   RTHUMB_REACH , RTHUMB_HOME , RTHUMB_TUCK
     )>;
   };

--- a/include/aekeynox/emulations/qwerty_lafayette.dtsi
+++ b/include/aekeynox/emulations/qwerty_lafayette.dtsi
@@ -18,7 +18,7 @@
 #ifdef KB_LAYOUT_AZERTY
 
   #if defined HT_HOME_ROW_MODS || defined HT_TWO_THUMB_KEYS
-    #define HRM_A    H_A Q
+    #define HRM_Q    H_A Q
     #define HRM_S    H_S S
     #define HRM_D    H_D D
     #define HRM_F    H_F F
@@ -26,7 +26,7 @@
     #define HRM_K    H_K K
     #define HRM_L    H_L L
   #else
-    #define HRM_A    &kp Q
+    #define HRM_Q    &kp Q
     #define HRM_S    &kp S
     #define HRM_D    &kp D
     #define HRM_F    &kp F
@@ -39,7 +39,7 @@
     display-name = "Base";
     bindings = <SELENIUM_KEYMAP_BINDINGS(
       &kp TAB    ,  &kp A  &kp Z  &kp E  &kp R  &kp T   ,   &kp Y  &kp U    &kp I  &kp O  &kp P   ,  &kp BACKSPACE ,
-      &kp ESCAPE ,  HRM_A  HRM_S  HRM_D  HRM_F  &kp G   ,   &kp H  HRM_J    HRM_K  HRM_L  &apos   ,  &kp ENTER     ,
+      &kp ESCAPE ,  HRM_Q  HRM_S  HRM_D  HRM_F  &kp G   ,   &kp H  HRM_J    HRM_K  HRM_L  &apos   ,  &kp ENTER     ,
       &kp LSHIFT ,  &kp W  &kp X  &kp C  &kp V  &kp B   ,   &kp N  &kp SEMI &comma &dot   &slash  ,  &kp RSHIFT    ,
          LTHUMB_TUCK , LTHUMB_HOME , LTHUMB_REACH   ,   RTHUMB_REACH , RTHUMB_HOME , RTHUMB_TUCK
     )>;

--- a/include/aekeynox/emulations/qwerty_lafayette.dtsi
+++ b/include/aekeynox/emulations/qwerty_lafayette.dtsi
@@ -17,11 +17,29 @@
 
 #ifdef KB_LAYOUT_AZERTY
 
+  #if defined HT_HOME_ROW_MODS || defined HT_TWO_THUMB_KEYS
+    #define HRM_A    H_A Q
+    #define HRM_S    H_S S
+    #define HRM_D    H_D D
+    #define HRM_F    H_F F
+    #define HRM_J    H_J J
+    #define HRM_K    H_K K
+    #define HRM_L    H_L L
+  #else
+    #define HRM_A    &kp Q
+    #define HRM_S    &kp S
+    #define HRM_D    &kp D
+    #define HRM_F    &kp F
+    #define HRM_J    &kp J
+    #define HRM_K    &kp K
+    #define HRM_L    &kp L
+  #endif
+
   &base_layer {
     display-name = "Base";
     bindings = <SELENIUM_KEYMAP_BINDINGS(
       &kp TAB    ,  &kp A  &kp Z  &kp E  &kp R  &kp T   ,   &kp Y  &kp U    &kp I  &kp O  &kp P   ,  &kp BACKSPACE ,
-      &kp ESCAPE ,  H_A Q  H_S S  H_D D  H_F F  &kp G   ,   &kp H  H_J J    H_K K  H_L L  &apos   ,  &kp ENTER     ,
+      &kp ESCAPE ,  HRM_A  HRM_S  HRM_D  HRM_F  &kp G   ,   &kp H  HRM_J    HRM_K  HRM_L  &apos   ,  &kp ENTER     ,
       &kp LSHIFT ,  &kp W  &kp X  &kp C  &kp V  &kp B   ,   &kp N  &kp SEMI &comma &dot   &slash  ,  &kp RSHIFT    ,
          LTHUMB_TUCK , LTHUMB_HOME , LTHUMB_REACH   ,   RTHUMB_REACH , RTHUMB_HOME , RTHUMB_TUCK
     )>;
@@ -30,11 +48,29 @@
 
 #elif defined KB_LAYOUT_QWERTY_INTL
 
+  #if defined HT_HOME_ROW_MODS || defined HT_TWO_THUMB_KEYS
+    #define HRM_A    H_A A
+    #define HRM_S    H_S S
+    #define HRM_D    H_D D
+    #define HRM_F    H_F F
+    #define HRM_J    H_J J
+    #define HRM_K    H_K K
+    #define HRM_L    H_L L
+  #else
+    #define HRM_A    &kp A
+    #define HRM_S    &kp S
+    #define HRM_D    &kp D
+    #define HRM_F    &kp F
+    #define HRM_J    &kp J
+    #define HRM_K    &kp K
+    #define HRM_L    &kp L
+  #endif
+
   &base_layer {
     display-name = "Base";
     bindings = <SELENIUM_KEYMAP_BINDINGS(
       &kp TAB    ,  &kp Q  &kp W  &kp E  &kp R  &kp T   ,   &kp Y  &kp U  &kp I  &kp O  &kp P     ,  &kp BACKSPACE ,
-      &kp ESCAPE ,  H_A A  H_S S  H_D D  H_F F  &kp G   ,   &kp H  H_J J  H_K K  H_L L  &apos     ,  &kp ENTER     ,
+      &kp ESCAPE ,  HRM_A  HRM_S  HRM_D  HRM_F  &kp G   ,   &kp H  HRM_J  HRM_K  HRM_L  &apos     ,  &kp ENTER     ,
       &kp LSHIFT ,  &kp Z  &kp X  &kp C  &kp V  &kp B   ,   &kp N  &kp M  &comma &dot   &kp FSLH  ,  &kp RSHIFT    ,
          LTHUMB_TUCK , LTHUMB_HOME , LTHUMB_REACH   ,   RTHUMB_REACH , RTHUMB_HOME , RTHUMB_TUCK
     )>;


### PR DESCRIPTION
Currently the emulation keymap systematically have HRM activated

This allows to disable HRM when using emulation and EZ or TT settings