### PR TITLE
feat: add mouse scroll on VimNav layer

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -47,55 +47,55 @@ include:
     shield: quacken_zero
     artifact-name: quacken_zero
     snippet: studio-rpc-usb-uart
-    cmake-args: -DCONFIG_ZMK_STUDIO=y
+    cmake-args: &cmake-args -DCONFIG_ZMK_STUDIO=y -DCONFIG_ZMK_POINTING=y
 
   # Totem + XIAO BLE
   - board: xiao_ble//zmk
     shield: totem_left
     artifact-name: totem_left
     snippet: studio-rpc-usb-uart
-    cmake-args: -DCONFIG_ZMK_STUDIO=y
+    cmake-args: *cmake-args
   - board: xiao_ble//zmk
     shield: totem_right
     artifact-name: totem_right
     snippet: studio-rpc-usb-uart
-    cmake-args: -DCONFIG_ZMK_STUDIO=y
+    cmake-args: *cmake-args
 
   # Corne + nice!nano v2
   - board: nice_nano@2//zmk
     shield: corne_left
     artifact-name: corne_left
     snippet: studio-rpc-usb-uart
-    cmake-args: -DCONFIG_ZMK_STUDIO=y
+    cmake-args: *cmake-args
   - board: nice_nano@2//zmk
     shield: corne_right
     artifact-name: corne_right
     snippet: studio-rpc-usb-uart
-    cmake-args: -DCONFIG_ZMK_STUDIO=y
+    cmake-args: *cmake-args
 
   # Sweep + nice!nano v2
   - board: nice_nano@2//zmk
     shield: cradio_left
     artifact-name: sweep_left
     snippet: studio-rpc-usb-uart
-    cmake-args: -DCONFIG_ZMK_STUDIO=y
+    cmake-args: *cmake-args
   - board: nice_nano@2//zmk
     shield: cradio_right
     artifact-name: sweep_right
     snippet: studio-rpc-usb-uart
-    cmake-args: -DCONFIG_ZMK_STUDIO=y
+    cmake-args: *cmake-args
 
   # Lily58 + nice!nano v2
   - board: nice_nano@2//zmk
     shield: lily58_left
     artifact-name: lily58_left
     snippet: studio-rpc-usb-uart
-    cmake-args: -DCONFIG_ZMK_STUDIO=y
+    cmake-args: *cmake-args
   - board: nice_nano@2//zmk
     shield: lily58_right
     artifact-name: lily58_right
     snippet: studio-rpc-usb-uart
-    cmake-args: -DCONFIG_ZMK_STUDIO=y
+    cmake-args: *cmake-args
 
   # Temper chocofi  + nice!nano v2
   - board: nice_nano@2//zmk
@@ -110,7 +110,7 @@ include:
     shield: re-gret
     artifact-name: re-gret
     snippet: studio-rpc-usb-uart
-    cmake-args: -DCONFIG_ZMK_STUDIO=y
+    cmake-args: *cmake-args
 
   ###
   # Standalone Keyboards (onboard MCU)
@@ -120,7 +120,7 @@ include:
   - board: quacken_flex/rp2040
     artifact-name: quacken_flex
     snippet: studio-rpc-usb-uart
-    cmake-args: -DCONFIG_ZMK_STUDIO=y
+    cmake-args: *cmake-args
 
   # Ferris (STM32F072)
   # Note: not enough memory for ZMK Studio
@@ -131,21 +131,21 @@ include:
   - board: corneish_zen_left//zmk
     artifact-name: corneish_zen_left
     snippet: studio-rpc-usb-uart
-    cmake-args: -DCONFIG_ZMK_STUDIO=y
+    cmake-args: *cmake-args
   - board: corneish_zen_right//zmk
     artifact-name: corneish_zen_right
     snippet: studio-rpc-usb-uart
-    cmake-args: -DCONFIG_ZMK_STUDIO=y
+    cmake-args: *cmake-args
 
   # Glove80
   - board: glove80_lh
     artifact-name: glove80_left
     snippet: studio-rpc-usb-uart
-    cmake-args: -DCONFIG_ZMK_STUDIO=y
+    cmake-args: *cmake-args
   - board: glove80_rh
     artifact-name: glove80_right
     snippet: studio-rpc-usb-uart
-    cmake-args: -DCONFIG_ZMK_STUDIO=y
+    cmake-args: *cmake-args
 
   # Go60
   - board: go60_lh

--- a/include/aekeynox/aliases.h
+++ b/include/aekeynox/aliases.h
@@ -70,3 +70,12 @@
   #define X_PREV &kp LA(LEFT)
   #define X_NEXT &kp LA(RIGHT)
 #endif
+
+// Mouse Actions
+#define ZMK_POINTING_DEFAULT_SCRL_VAL 25  // increase from the default 10 which is too slow
+#include <dt-bindings/zmk/pointing.h>
+
+#define X_MSC_L &msc SCRL_LEFT
+#define X_MSC_D &msc SCRL_DOWN
+#define X_MSC_U &msc SCRL_UP
+#define X_MSC_R &msc SCRL_RIGHT

--- a/include/aekeynox/selenium.keymap
+++ b/include/aekeynox/selenium.keymap
@@ -75,7 +75,7 @@
       bindings = <SELENIUM_KEYMAP_BINDINGS(
         &trans  ,  &none    X_CTL_W  &vim_prev &vim_next &none     ,   &kp HOME &kp PG_DN &kp PG_UP &kp END   &kp DEL ,  &trans ,
         &trans  ,  X_ALL    X_SAVE   X_SHTAB   &kp TAB   &none     ,   &kp LEFT &kp DOWN  &kp UP    &kp RIGHT &none   ,  &trans ,
-        &trans  ,  X_UNDO   X_CUT    X_COPY    X_PASTE   X_REDO    ,   &none    &none     &none     &none     &none   ,  &trans ,
+        &trans  ,  X_UNDO   X_CUT    X_COPY    X_PASTE   X_REDO    ,   X_MSC_L  X_MSC_D   X_MSC_U   X_MSC_R   &none   ,  &trans ,
             &kp CAPS , &sc FN_MEDIA_LAYER DEL , &mo NUM_ROW_LAYER  ,   &trans ,  &mo FN_MEDIA_LAYER , &EZ_LSK(RALT)
       )>;
     };


### PR DESCRIPTION
This PR adds mouse scroll emulation actions on the right hand's lower row, similar to [what is done in Arsenik](https://github.com/OneDeadKey/arsenik/blob/47809b86fdc7bf8b13d377be6d5c12df7f1ad7d1/kanata/deflayer/navigation_vim.kbd#L41-L45).