### PR TITLE
Docs/word on activating actions in fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This repository allows to build your firmware with GitHub Actions (GHA):
 
 1. [create a GitHub account](https://github.com/signup) if you don’t already have one
 2. [fork](https://github.com/OneDeadKey/zmk-config-aekeynox/fork) this repository
-3. On your fork’s GitHub page, visit the Actions tab to enable workflows — by default, they are disabled on newly created forks
+3. on your fork’s GitHub page, visit the Actions tab to enable workflows — by default, they are disabled on newly created forks
 4. set your configuration in [`include/aekeynox/settings.h`](#keymapssettingsh)<br>
    *(this step is **required** for non-QWERTY layouts)*
 5. make sure your keyboard is configured properly in [`build.yaml`](#buildyaml)<br>

--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ This repository allows to build your firmware with GitHub Actions (GHA):
 
 1. [create a GitHub account](https://github.com/signup) if you don’t already have one
 2. [fork](https://github.com/OneDeadKey/zmk-config-aekeynox/fork) this repository
-3. on your fork’s GitHub page, visit the Actions tab to enable workflows — by default, they are disabled on newly created forks
+3. on your fork’s GitHub page, visit the Actions tab to enable workflows<br>
+   *(by default, they are disabled on newly created forks)*
 4. set your configuration in [`include/aekeynox/settings.h`](#keymapssettingsh)<br>
    *(this step is **required** for non-QWERTY layouts)*
 5. make sure your keyboard is configured properly in [`build.yaml`](#buildyaml)<br>

--- a/README.md
+++ b/README.md
@@ -27,11 +27,12 @@ This repository allows to build your firmware with GitHub Actions (GHA):
 
 1. [create a GitHub account](https://github.com/signup) if you don’t already have one
 2. [fork](https://github.com/OneDeadKey/zmk-config-aekeynox/fork) this repository
-3. set your configuration in [`include/aekeynox/settings.h`](#keymapssettingsh)<br>
+3. On your fork’s GitHub page, visit the Actions tab to enable workflows — by default, they are disabled on newly created forks
+4. set your configuration in [`include/aekeynox/settings.h`](#keymapssettingsh)<br>
    *(this step is **required** for non-QWERTY layouts)*
-4. make sure your keyboard is configured properly in [`build.yaml`](#buildyaml)<br>
+5. make sure your keyboard is configured properly in [`build.yaml`](#buildyaml)<br>
    *(this step is **required** for composite keebs based on Pro Micro, XIAO, etc.)*
-5. save, commit, push
+6. save, commit, push
 
 Your firmware will now be built automatically by GitHub’s CI:
 


### PR DESCRIPTION
Adds an installation step in README addressing the fact that on a newly created fork, workflows are disabled by default. Users need to enable them by visiting the Actions tab and clicking a big green button — earlier pushes won’t automatically trigger workflows after these are enabled.