### PR TITLE
fix: disable HRM when necessary in emulated keymaps

### DIFF
--- a/include/aekeynox/emulations/dvorak.dtsi
+++ b/include/aekeynox/emulations/dvorak.dtsi
@@ -1,3 +1,5 @@
+#include "hrm.h"
+
 &base_layer {
   display-name = "Base";
   bindings = <SELENIUM_KEYMAP_BINDINGS(

--- a/include/aekeynox/emulations/ergol.dtsi
+++ b/include/aekeynox/emulations/ergol.dtsi
@@ -17,6 +17,8 @@
  * Base Layer (host-specific)
 ******************************************************************************/
 
+#include "hrm.h"
+
 #ifdef KB_LAYOUT_AZERTY
 
   &base_layer {

--- a/include/aekeynox/emulations/hrm.h
+++ b/include/aekeynox/emulations/hrm.h
@@ -1,7 +1,7 @@
 // Disable home row modifiers when necessary:
 // this is just a hack to re-define the base keymap,
 // keeping the same syntax whether HRMs are enabled or not.
-#if defined HT_NONE or defined HT_THUMB_TAPS
+#if defined HT_NONE || defined HT_THUMB_TAPS
   #undef  H_A
   #define H_A &kp
   #undef  H_S

--- a/include/aekeynox/emulations/hrm.h
+++ b/include/aekeynox/emulations/hrm.h
@@ -1,0 +1,21 @@
+// Disable home row modifiers when necessary:
+// this is just a hack to re-define the base keymap,
+// keeping the same syntax whether HRMs are enabled or not.
+#if defined HT_NONE || defined HT_THUMB_TAPS
+  #undefine H_A
+  #undefine H_S
+  #undefine H_D
+  #undefine H_F
+  #undefine H_J
+  #undefine H_K
+  #undefine H_L
+  #undefine H_SEMI
+  #define H_A &kp
+  #define H_S &kp
+  #define H_D &kp
+  #define H_F &kp
+  #define H_J &kp
+  #define H_K &kp
+  #define H_L &kp
+  #define H_SEMI &kp
+#endif

--- a/include/aekeynox/emulations/hrm.h
+++ b/include/aekeynox/emulations/hrm.h
@@ -2,20 +2,20 @@
 // this is just a hack to re-define the base keymap,
 // keeping the same syntax whether HRMs are enabled or not.
 #if defined HT_NONE || defined HT_THUMB_TAPS
-  #undefine H_A
-  #undefine H_S
-  #undefine H_D
-  #undefine H_F
-  #undefine H_J
-  #undefine H_K
-  #undefine H_L
-  #undefine H_SEMI
+  #undef  H_A
   #define H_A &kp
+  #undef  H_S
   #define H_S &kp
+  #undef  H_D
   #define H_D &kp
+  #undef  H_F
   #define H_F &kp
+  #undef  H_J
   #define H_J &kp
+  #undef  H_K
   #define H_K &kp
+  #undef  H_L
   #define H_L &kp
+  #undef  H_SEMI
   #define H_SEMI &kp
 #endif

--- a/include/aekeynox/emulations/hrm.h
+++ b/include/aekeynox/emulations/hrm.h
@@ -1,7 +1,7 @@
 // Disable home row modifiers when necessary:
 // this is just a hack to re-define the base keymap,
 // keeping the same syntax whether HRMs are enabled or not.
-#if defined HT_NONE || defined HT_THUMB_TAPS
+#if defined HT_NONE or defined HT_THUMB_TAPS
   #undef  H_A
   #define H_A &kp
   #undef  H_S

--- a/include/aekeynox/emulations/qwerty_lafayette.dtsi
+++ b/include/aekeynox/emulations/qwerty_lafayette.dtsi
@@ -17,6 +17,8 @@
  * Base Layer (host-specific)
 ******************************************************************************/
 
+#include "hrm.h"
+
 #ifdef KB_LAYOUT_AZERTY
 
   &base_layer {


### PR DESCRIPTION
Alternative implementation of #83, possibly silly.