### PR TITLE
chore: cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,9 @@ Your firmware will now be built automatically by GitHub’s CI:
 - unzip, pick the firmware matching your keeb
 - flash your keeb
 
-Note: if you encounter Bluetooth connection issues, flashing your keyboard with the appropriate `settings_reset` firmware might help. More info [here](https://zmk.dev/docs/troubleshooting/connection-issues)
+Note: if you encounter Bluetooth connection issues, it might help to flash your keyboard
+with the `settings_reset` firmware matching your controller.
+More info [in the ZMK documentation](https://zmk.dev/docs/troubleshooting/connection-issues).
 
 
 ## Configuration

--- a/build.yaml
+++ b/build.yaml
@@ -42,14 +42,14 @@ include:
   # => make sure the `board` field matches the MCU on your keyboard
   ##
 
-  # Quacken Zero + SparkFun RP2040
+    # Quacken Zero + SparkFun RP2040
   - board: sparkfun_pro_micro_rp2040//zmk
     shield: quacken_zero
     artifact-name: quacken_zero
     snippet: studio-rpc-usb-uart
     cmake-args: &cmake-args -DCONFIG_ZMK_STUDIO=y -DCONFIG_ZMK_POINTING=y
 
-  # Totem + XIAO BLE
+    # Totem + XIAO BLE
   - board: xiao_ble//zmk
     shield: totem_left
     artifact-name: totem_left
@@ -58,10 +58,8 @@ include:
   - board: xiao_ble//zmk
     shield: totem_right
     artifact-name: totem_right
-    snippet: studio-rpc-usb-uart
-    cmake-args: *cmake-args
 
-  # Corne + nice!nano v2
+    # Corne + nice!nano v2
   - board: nice_nano@2//zmk
     shield: corne_left
     artifact-name: corne_left
@@ -70,10 +68,8 @@ include:
   - board: nice_nano@2//zmk
     shield: corne_right
     artifact-name: corne_right
-    snippet: studio-rpc-usb-uart
-    cmake-args: *cmake-args
 
-  # Sweep + nice!nano v2
+    # Sweep + nice!nano v2
   - board: nice_nano@2//zmk
     shield: cradio_left
     artifact-name: sweep_left
@@ -82,10 +78,8 @@ include:
   - board: nice_nano@2//zmk
     shield: cradio_right
     artifact-name: sweep_right
-    snippet: studio-rpc-usb-uart
-    cmake-args: *cmake-args
 
-  # Lily58 + nice!nano v2
+    # Lily58 + nice!nano v2
   - board: nice_nano@2//zmk
     shield: lily58_left
     artifact-name: lily58_left
@@ -94,10 +88,8 @@ include:
   - board: nice_nano@2//zmk
     shield: lily58_right
     artifact-name: lily58_right
-    snippet: studio-rpc-usb-uart
-    cmake-args: *cmake-args
 
-  # Temper chocofi  + nice!nano v2
+    # Temper/Chocofi + nice!nano v2
   - board: nice_nano@2//zmk
     shield: temper_left nice_view_adapter nice_view
     artifact-name: temper_left
@@ -114,61 +106,60 @@ include:
     snippet: studio-rpc-usb-uart
     cmake-args: *cmake-args
 
+
   ###
   # Standalone Keyboards (onboard MCU)
   ##
 
-  # Quacken Flex (RP2040)
+    # Quacken Flex (RP2040)
   - board: quacken_flex/rp2040
     artifact-name: quacken_flex
     snippet: studio-rpc-usb-uart
     cmake-args: *cmake-args
 
-  # Ferris (STM32F072)
-  # Note: not enough memory for ZMK Studio
+    # Ferris (STM32F072)
+    # Note: not enough memory for ZMK Studio
   - board: ferris//zmk
     artifact-name: ferris
 
-  # Corneish Zen (nRF52840)
+    # Corneish Zen (nRF52840)
   - board: corneish_zen_left//zmk
     artifact-name: corneish_zen_left
     snippet: studio-rpc-usb-uart
     cmake-args: *cmake-args
   - board: corneish_zen_right//zmk
     artifact-name: corneish_zen_right
-    snippet: studio-rpc-usb-uart
-    cmake-args: *cmake-args
 
-  # Glove80
+    # Glove80
   - board: glove80_lh
     artifact-name: glove80_left
     snippet: studio-rpc-usb-uart
     cmake-args: *cmake-args
   - board: glove80_rh
     artifact-name: glove80_right
-    snippet: studio-rpc-usb-uart
-    cmake-args: *cmake-args
 
-  # Go60
+    # Go60
   - board: go60_lh
     artifact-name: go60_left
     snippet: studio-rpc-usb-uart
     cmake-args: -DCONFIG_ZMK_STUDIO=y
   - board: go60_rh
     artifact-name: go60_right
-    snippet: studio-rpc-usb-uart
-    cmake-args: -DCONFIG_ZMK_STUDIO=y
+
 
   ###
-  # Resets
+  # BLE Resets
+  #
+  # Some Bluetooth connection issues require flashing/resettting the MCU,
+  # see: https://zmk.dev/docs/troubleshooting/connection-issues
   ##
 
-  # XIAO BLE (Totem)
+    # XIAO BLE
   - board: xiao_ble//zmk
     shield: settings_reset
     artifact-name: xiao_ble_settings_reset
 
-  # nice!nano v2 (Corne, Sweep, Lily58)
+    # nice!nano v2
   - board: nice_nano@2//zmk
     shield: settings_reset
     artifact-name: nice_nano_v2_settings_reset


### PR DESCRIPTION
* For split keyboards, the right parts should not enable ZMK Studio
* (slightly) better documentation regarding BLE resets

Fixes #21.