### PR TITLE
fix: chocofi repository

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -101,6 +101,8 @@ include:
   - board: nice_nano@2//zmk
     shield: temper_left nice_view_adapter nice_view
     artifact-name: temper_left
+    snippet: studio-rpc-usb-uart
+    cmake-args: *cmake-args
   - board: nice_nano@2//zmk
     shield: temper_right nice_view_adapter nice_view
     artifact-name: temper_right

--- a/config/west.yml
+++ b/config/west.yml
@@ -27,7 +27,7 @@ manifest:
       remote: cfergeau
       revision: zmk-module
     - name: temper-zmk-config
-      remote: raeedcho
+      remote: NuclearSquid
       revision: main
     - name: zmk-config-go60
       remote: rloutier

--- a/config/west.yml
+++ b/config/west.yml
@@ -26,7 +26,7 @@ manifest:
     - name: zmk-config-totem
       remote: cfergeau
       revision: zmk-module
-      # We rely on a fork of the original ZMK Temper module, as there are
+      # We rely on a fork of `raeedcho`'s ZMK Temper module, as there are
       # long-standing issues on the original repo that have never been fixed
       # (despite a couple of PRs being opened). More info here:
       # https://github.com/OneDeadKey/zmk-config-aekeynox/pull/101

--- a/config/west.yml
+++ b/config/west.yml
@@ -32,7 +32,7 @@ manifest:
       # https://github.com/OneDeadKey/zmk-config-aekeynox/pull/101
     - name: temper-zmk-config
       remote: NuclearSquid
-      revision: main
+      revision: aekeynox
     - name: zmk-config-go60
       remote: rloutier
       revision: main

--- a/config/west.yml
+++ b/config/west.yml
@@ -26,6 +26,10 @@ manifest:
     - name: zmk-config-totem
       remote: cfergeau
       revision: zmk-module
+      # We rely on a fork of the original ZMK Temper module, as there are
+      # long-standing issues on the original repo that have never been fixed
+      # (despite a couple of PRs being opened). More info here:
+      # https://github.com/OneDeadKey/zmk-config-aekeynox/pull/101
     - name: temper-zmk-config
       remote: NuclearSquid
       revision: main


### PR DESCRIPTION
Fixes #84 

The original repo for the Chocofi has a couple of issues (poor wake-up management and no support for zmk-studio). PRs were opened for a while but haven’t been merged, so I’ve forked the repo to aggregate various unmerged fixes, and used that in place of the original repo.

@iten828 I do not own that keyboard, so if you could try out this patch that would be great ^^