### PR TITLE
feat: Colemak over Qwerty emulation support

### DIFF
--- a/include/aekeynox/emulations/colemak.dtsi
+++ b/include/aekeynox/emulations/colemak.dtsi
@@ -1,0 +1,8 @@
+&base_layer {
+  bindings = <SELENIUM_KEYMAP_BINDINGS(
+    &kp TAB    ,  &kp Q  &kp W  &kp F  &kp P  &kp G   ,   &kp J  &kp L  &kp U     &kp Y   &kp SEMI  ,  &kp BACKSPACE ,
+    &kp ESCAPE ,  &H4 A  &H3 R  &H2 E  &H1 T  &kp D   ,   &kp H  &H1 N  &H2 E     &H3 I   &H4 O     ,  &kp ENTER     ,
+    &kp LSHIFT ,  &kp Z  &kp X  &kp C  &kp V  &kp B   ,   &kp K  &kp M  &kp COMMA &kp DOT &kp FSLH  ,  &kp RSHIFT    ,
+           LTHUMB_TUCK , LTHUMB_HOME , LTHUMB_REACH   ,   RTHUMB_REACH , RTHUMB_HOME , RTHUMB_TUCK
+  )>;
+};

--- a/include/aekeynox/emulations/colemak_dh.dtsi
+++ b/include/aekeynox/emulations/colemak_dh.dtsi
@@ -1,0 +1,8 @@
+&base_layer {
+  bindings = <SELENIUM_KEYMAP_BINDINGS(
+    &kp TAB    ,  &kp Q  &kp W  &kp F  &kp P  &kp B   ,   &kp J  &kp L  &kp U     &kp Y   &kp SEMI  ,  &kp BACKSPACE ,
+    &kp ESCAPE ,  &H4 A  &H3 R  &H2 E  &H1 T  &kp G   ,   &kp M  &H1 N  &H2 E     &H3 I   &H4 O     ,  &kp ENTER     ,
+    &kp LSHIFT ,  &kp Z  &kp X  &kp C  &kp D  &kp V   ,   &kp K  &kp H  &kp COMMA &kp DOT &kp FSLH  ,  &kp RSHIFT    ,
+           LTHUMB_TUCK , LTHUMB_HOME , LTHUMB_REACH   ,   RTHUMB_REACH , RTHUMB_HOME , RTHUMB_TUCK
+  )>;
+};

--- a/include/aekeynox/selenium.keymap
+++ b/include/aekeynox/selenium.keymap
@@ -123,7 +123,11 @@
 };
 
 // Emulated layouts (experimental!)
-#ifdef KB_EMULATION_DVORAK
+#ifdef KB_EMULATION_COLEMAK
+  #include "emulations/colemak.dtsi"
+#elif defined KB_EMULATION_COLEMAK_DH
+  #include "emulations/colemak_dh.dtsi"
+#elif defined KB_EMULATION_DVORAK
   #include "emulations/dvorak.dtsi"
 #elif defined KB_EMULATION_ERGOL
   #include "emulations/ergol.dtsi"

--- a/include/aekeynox/settings.h
+++ b/include/aekeynox/settings.h
@@ -38,6 +38,8 @@
 //  - Keymaps for other languages and host layouts are trickier, and provide a
 //    partial emulation only. QWERTY-intl hosts usually give the best results.
 
+// #define KB_EMULATION_COLEMAK          // host: QWERTY
+// #define KB_EMULATION_COLEMAK_DH       // host: QWERTY
 // #define KB_EMULATION_DVORAK           // host: QWERTY
 // #define KB_EMULATION_ERGOL            // host: QWERTY-intl or AZERTY
 // #define KB_EMULATION_QWERTY_LAFAYETTE // host: QWERTY-intl or AZERTY

--- a/tests.yaml
+++ b/tests.yaml
@@ -4,7 +4,7 @@ include:
   ###
   # Keyboard Configurations
   ##
-  
+
   # default config
   - board: quacken_flex/rp2040
     artifact-name: default
@@ -33,7 +33,17 @@ include:
   ###
   # Layout Emulations
   ##
-  
+
+  # Dvorak emulation on Qwerty
+  - board: quacken_flex/rp2040
+    artifact-name: qwerty_to_colemak
+    cmake-args: -DDTS_EXTRA_CPPFLAGS="-DCI_IGNORE_USER_SETTINGS;-DKB_LAYOUT_QWERTY;-DKB_EMULATION_COLEMAK"
+
+  # Dvorak emulation on Qwerty
+  - board: quacken_flex/rp2040
+    artifact-name: qwerty_to_colemak_dh
+    cmake-args: -DDTS_EXTRA_CPPFLAGS="-DCI_IGNORE_USER_SETTINGS;-DKB_LAYOUT_QWERTY;-DKB_EMULATION_COLEMAK_DH"
+
   # Dvorak emulation on Qwerty
   - board: quacken_flex/rp2040
     artifact-name: qwerty_to_dvorak


### PR DESCRIPTION
This PR adds support for emulating Colemak(dh) over qwerty in Selenium.