### PR TITLE
fix: reorder HRM keys

### DIFF
--- a/include/aekeynox/hold_taps.dtsi
+++ b/include/aekeynox/hold_taps.dtsi
@@ -39,15 +39,15 @@
 // Unconditionnal home row mods, needed by the fn/media layer, since combining
 // modifiers on the thumb-taps variant with this layer can be tricky.
 // Hopefully, this issue can be cleanly resolved with mod-holds someday.
-#define UH1 hrm GUI_OPT
+#define UH1 hrm ALT_CTL
 #define UH2 hrm CTL_CMD
-#define UH3 hrm ALT_CTL
+#define UH3 hrm GUI_OPT
 #define UH4 hrm LSHIFT
 
 #if defined HT_HOME_ROW_MODS || defined HT_TWO_THUMB_KEYS
-  #define H1 hrm GUI_OPT
+  #define H1 hrm ALT_CTL
   #define H2 hrm CTL_CMD
-  #define H3 hrm ALT_CTL
+  #define H3 hrm GUI_OPT
 #else
   #define H1 kp
   #define H2 kp


### PR DESCRIPTION
As mentioned by @iten828 in https://github.com/OneDeadKey/zmk-config-aekeynox/pull/101#issuecomment-5259576899

> &H3 and &H1 seems to be swapped, so home row looks like this now:
> ALT_CTL CTL_CMD GUI_OPT ---- GUI_OPT CTL_CMD ALT_CTL

Following #99, &H1 and &H3 had been swapped. Here's a quick fix.