### PR TITLE
security: pin external dependencies

### DIFF
--- a/config/west.yml
+++ b/config/west.yml
@@ -53,7 +53,7 @@ manifest:
       remote: NuclearSquid
       revision: aekeynox
 
-      # Adds support for the `go60` (split nrf52840 board).
+      # Go60: split nrf52840 board
       # A fork of Moergo's ZMK go60 module, to migrate it to ZMK main
     - name: zmk-config-go60
       remote: rloutier

--- a/config/west.yml
+++ b/config/west.yml
@@ -54,7 +54,7 @@ manifest:
       revision: aekeynox
 
       # Go60: split nrf52840-based board
-      # A fork of Moergo's ZMK go60 module, to migrate it to ZMK main
+      # A fork of MoErgo's ZMK go60 module, to migrate it to ZMK main
     - name: zmk-config-go60
       remote: rloutier
       revision: 1bb1f847162f5ccec162c5ba6516d0c73b6a8c39

--- a/config/west.yml
+++ b/config/west.yml
@@ -21,6 +21,7 @@ manifest:
       url-base: https://github.com/rloutier
     - name: rschenk
       url-base: https://github.com/rschenk
+
   projects:
     - name: zmk
       remote: zmkfirmware
@@ -29,12 +30,15 @@ manifest:
       # https://github.com/OneDeadKey/zmk-config-aekeynox/pull/67
       revision: 9917e2f1371d5bb051bf8eb782c1297db41d742b
       import: app/west.yml
+
     - name: zmk-keyboard-quacken
       remote: NuclearSquid
       revision: aekeynox
+
     - name: zmk-config-totem
       remote: cfergeau
       revision: 9677c2fd5af7cee784aafb1b52a25a33357336c2
+
       # We rely on a fork of `raeedcho`'s ZMK Temper module, as there are
       # long-standing issues on the original repo that have never been fixed
       # (despite a couple of PRs being opened). More info here:
@@ -42,11 +46,14 @@ manifest:
     - name: temper-zmk-config
       remote: NuclearSquid
       revision: aekeynox
+
     - name: zmk-config-go60
       remote: rloutier
       revision: 1bb1f847162f5ccec162c5ba6516d0c73b6a8c39
+
     - name: zmk-keyboard-re-gret
       remote: rschenk
       revision: 34ca1fc7dc6991475b0c20f2c8361598e7aaeaca
+
   self:
     path: config

--- a/config/west.yml
+++ b/config/west.yml
@@ -21,11 +21,11 @@ manifest:
       url-base: https://github.com/rschenk
 
   projects:
-    - name: zmk
-      remote: zmkfirmware
       # Pin ZMK to the latest board fix of the `main` branch on 2026-06-13.
       # https://github.com/Nuclear-Squid/zmk-keyboard-quacken/pull/49#issuecomment-4153385353
       # https://github.com/OneDeadKey/zmk-config-aekeynox/pull/67
+    - name: zmk
+      remote: zmkfirmware
       revision: 9917e2f1371d5bb051bf8eb782c1297db41d742b
       import: app/west.yml
 

--- a/config/west.yml
+++ b/config/west.yml
@@ -41,7 +41,7 @@ manifest:
       revision: aekeynox
 
       # Totem: split xiao-compatible shield
-      # A fork of `GEIGEIGEIST`'s ZMK go60 module, to migrate it to ZMK main
+      # A fork of `GEIGEIGEIST`'s ZMK Totem module, to migrate it to ZMK main
     - name: zmk-config-totem
       remote: cfergeau
       revision: 9677c2fd5af7cee784aafb1b52a25a33357336c2
@@ -53,7 +53,7 @@ manifest:
       remote: NuclearSquid
       revision: aekeynox
 
-      # Go60: split nrf52840 board
+      # Go60: split nrf52840-based board
       # A fork of Moergo's ZMK go60 module, to migrate it to ZMK main
     - name: zmk-config-go60
       remote: rloutier

--- a/config/west.yml
+++ b/config/west.yml
@@ -59,7 +59,7 @@ manifest:
       remote: rloutier
       revision: 1bb1f847162f5ccec162c5ba6516d0c73b6a8c39
 
-      # Re-gret: unibody xiao-compatible shield
+      # Re-gret: unibody XIAO-compatible shield, 34 keys
     - name: zmk-keyboard-re-gret
       remote: rschenk
       revision: 34ca1fc7dc6991475b0c20f2c8361598e7aaeaca

--- a/config/west.yml
+++ b/config/west.yml
@@ -34,8 +34,8 @@ manifest:
       # Community keyboards (not officially supported by ZMK)
       ##
 
-      # - Quacken_flex: unibody rp2040-based board
-      # - Quacken_zero: unibody ProMicro-compatible shield
+      # - Quacken Flex: unibody rp2040-based board
+      # - Quacken Zero: unibody ProMicro-compatible shield
     - name: zmk-keyboard-quacken
       remote: NuclearSquid
       revision: aekeynox

--- a/config/west.yml
+++ b/config/west.yml
@@ -7,6 +7,7 @@
 # - For any other repo, we pin the exact commit hash we need. Feel free to
 #   open a PR to update this hash if improvements are made.
 
+
 manifest:
   remotes:
     - name: zmkfirmware

--- a/config/west.yml
+++ b/config/west.yml
@@ -34,8 +34,8 @@ manifest:
       # Community keyboards (not officially supported by ZMK)
       ##
 
-      # - Quacken Flex: unibody rp2040-based board
-      # - Quacken Zero: unibody ProMicro-compatible shield
+      # Quacken Flex: unibody rp2040-based board
+      # Quacken Zero: unibody ProMicro-compatible shield
     - name: zmk-keyboard-quacken
       remote: NuclearSquid
       revision: aekeynox

--- a/config/west.yml
+++ b/config/west.yml
@@ -15,8 +15,6 @@ manifest:
       url-base: https://github.com/cfergeau
     - name: NuclearSquid
       url-base: https://github.com/Nuclear-Squid
-    - name: raeedcho
-      url-base: https://github.com/raeedcho
     - name: rloutier
       url-base: https://github.com/rloutier
     - name: rschenk

--- a/config/west.yml
+++ b/config/west.yml
@@ -1,3 +1,12 @@
+# For security and stability reasons, every external dependencies must be pinned.
+# This ensures maintainers are in control and are able to review changes before
+# applying them here.
+#
+# - For repos maintained by OneDeadKey or their members, we use an `aekeynox`
+#   branch as a stable release for the dependency.
+# - For any other repo, we pin the exact commit hash we need. Feel free to
+#   open a PR to update this hash if improvements are made.
+
 manifest:
   remotes:
     - name: zmkfirmware
@@ -22,10 +31,10 @@ manifest:
       import: app/west.yml
     - name: zmk-keyboard-quacken
       remote: NuclearSquid
-      revision: zmk-main
+      revision: aekeynox
     - name: zmk-config-totem
       remote: cfergeau
-      revision: zmk-module
+      revision: 9677c2fd5af7cee784aafb1b52a25a33357336c2
       # We rely on a fork of `raeedcho`'s ZMK Temper module, as there are
       # long-standing issues on the original repo that have never been fixed
       # (despite a couple of PRs being opened). More info here:
@@ -35,9 +44,9 @@ manifest:
       revision: aekeynox
     - name: zmk-config-go60
       remote: rloutier
-      revision: main
+      revision: 1bb1f847162f5ccec162c5ba6516d0c73b6a8c39
     - name: zmk-keyboard-re-gret
       remote: rschenk
-      revision: main
+      revision: 34ca1fc7dc6991475b0c20f2c8361598e7aaeaca
   self:
     path: config

--- a/config/west.yml
+++ b/config/west.yml
@@ -46,7 +46,7 @@ manifest:
       remote: cfergeau
       revision: 9677c2fd5af7cee784aafb1b52a25a33357336c2
 
-      # Temper: split promicro-compatible shield
+      # Temper: split ProMicro-compatible shield
       # A fork of `raeedcho`'s ZMK Temper module including long-standing patch proposals.
       # https://github.com/OneDeadKey/zmk-config-aekeynox/pull/101
     - name: temper-zmk-config

--- a/config/west.yml
+++ b/config/west.yml
@@ -46,7 +46,7 @@ manifest:
       remote: cfergeau
       revision: 9677c2fd5af7cee784aafb1b52a25a33357336c2
 
-      # Temper: split ProMicro-compatible shield
+      # Temper/Chocofi: split ProMicro-compatible shield
       # A fork of `raeedcho`'s ZMK Temper module including long-standing patch proposals.
       # https://github.com/OneDeadKey/zmk-config-aekeynox/pull/101
     - name: temper-zmk-config

--- a/config/west.yml
+++ b/config/west.yml
@@ -35,7 +35,7 @@ manifest:
       ##
 
       # - Quacken_flex: unibody rp2040-based board
-      # - Quacken_zero: unibody promicro-compatible shield
+      # - Quacken_zero: unibody ProMicro-compatible shield
     - name: zmk-keyboard-quacken
       remote: NuclearSquid
       revision: aekeynox

--- a/config/west.yml
+++ b/config/west.yml
@@ -40,7 +40,7 @@ manifest:
       remote: NuclearSquid
       revision: aekeynox
 
-      # Totem: split xiao-compatible shield
+      # Totem: split XIAO-compatible shield
       # A fork of `GEIGEIGEIST`'s ZMK Totem module, to migrate it to ZMK main
     - name: zmk-config-totem
       remote: cfergeau

--- a/config/west.yml
+++ b/config/west.yml
@@ -1,4 +1,4 @@
-# For security and stability reasons, every external dependencies must be pinned.
+# For security and stability reasons, every external dependency must be pinned.
 # This ensures maintainers are in control and are able to review changes before
 # applying them here.
 #

--- a/config/west.yml
+++ b/config/west.yml
@@ -7,8 +7,8 @@
 # - For any other repo, we pin the exact commit hash we need. Feel free to
 #   open a PR to update this hash if improvements are made.
 
-
 manifest:
+
   remotes:
     - name: zmkfirmware
       url-base: https://github.com/zmkfirmware

--- a/config/west.yml
+++ b/config/west.yml
@@ -30,26 +30,36 @@ manifest:
       revision: 9917e2f1371d5bb051bf8eb782c1297db41d742b
       import: app/west.yml
 
+      ###
+      # Community keyboards (not officially supported by ZMK)
+      ##
+
+      # - Quacken_flex: unibody rp2040-based board
+      # - Quacken_zero: unibody promicro-compatible shield
     - name: zmk-keyboard-quacken
       remote: NuclearSquid
       revision: aekeynox
 
+      # Totem: split xiao-compatible shield
+      # A fork of `GEIGEIGEIST`'s ZMK go60 module, to migrate it to ZMK main
     - name: zmk-config-totem
       remote: cfergeau
       revision: 9677c2fd5af7cee784aafb1b52a25a33357336c2
 
-      # We rely on a fork of `raeedcho`'s ZMK Temper module, as there are
-      # long-standing issues on the original repo that have never been fixed
-      # (despite a couple of PRs being opened). More info here:
+      # Temper: split promicro-compatible shield
+      # A fork of `raeedcho`'s ZMK Temper module including long-standing patch proposals.
       # https://github.com/OneDeadKey/zmk-config-aekeynox/pull/101
     - name: temper-zmk-config
       remote: NuclearSquid
       revision: aekeynox
 
+      # Adds support for the `go60` (split nrf52840 board).
+      # A fork of Moergo's ZMK go60 module, to migrate it to ZMK main
     - name: zmk-config-go60
       remote: rloutier
       revision: 1bb1f847162f5ccec162c5ba6516d0c73b6a8c39
 
+      # Re-gret: unibody xiao-compatible shield
     - name: zmk-keyboard-re-gret
       remote: rschenk
       revision: 34ca1fc7dc6991475b0c20f2c8361598e7aaeaca


### PR DESCRIPTION
After realizing the possible security impact of accepting automatically any patch made on external repos we use, I went ahead and pinned every one of them. As of today, those commit hashes point to the head of the branch we were following, so this should not change anything in the code itself.