### PR TITLE
feat: callum mods

### DIFF
--- a/include/aekeynox/defaults.h
+++ b/include/aekeynox/defaults.h
@@ -29,6 +29,10 @@
   #define ENABLE_HOME_ROW_MODS
 #endif
 
+#if defined VIM_NAVIGATION + defined CALLUM_NAVIGATION > 1
+  #error "Please select only one navigation style at a time"
+#endif
+
 // Memory
 
 #ifdef LOW_MEMORY_DEVICE

--- a/include/aekeynox/defaults.h
+++ b/include/aekeynox/defaults.h
@@ -25,6 +25,10 @@
   #error "Please select only up to one hold-tap configuration at a time"
 #endif
 
+#if (defined HT_HOME_ROW_MODS || defined HT_TWO_THUMB_KEYS) && !defined CALLUM_NAVIGATION
+  #define ENABLE_HOME_ROW_MODS
+#endif
+
 // Memory
 
 #ifdef LOW_MEMORY_DEVICE

--- a/include/aekeynox/hold_taps.dtsi
+++ b/include/aekeynox/hold_taps.dtsi
@@ -14,12 +14,13 @@
 #define SYMBOLS_LAYER  2
 #define VIM_NAV_LAYER  3
 #define NAV_NUM_LAYER  4
-#define NUM_ROW_LAYER  5
-#define FN_MEDIA_LAYER 6
+#define CALLUM_LAYER   5
+#define NUM_ROW_LAYER  6
+#define FN_MEDIA_LAYER 7
 
 // Potentially used by other keymaps deriving from this one, who may add extra layers.
 // Make sure this stays equal to <index_of_last_layer> + 1
-#define EXTRA_LAYERS_START_INDEX 7
+#define EXTRA_LAYERS_START_INDEX 8
 
 
 /**
@@ -74,7 +75,13 @@
   #define NAV_SC &sc
 #endif
 
-#ifdef VIM_NAVIGATION
+#if defined HT_CALLUM_MODS || defined HT_CALLUM_MODS_2TK
+  #define NAV_LAYER CALLUM_LAYER
+  #define NUM_LAYER NUM_ROW_LAYER
+  #define HRM_LAYER NUM_ROW_LAYER
+  #define S34_LAYER NUM_ROW_LAYER
+  #define REACH_TAP ESCAPE
+#elifdef VIM_NAVIGATION
   #define NAV_LAYER VIM_NAV_LAYER
   #define NUM_LAYER NUM_ROW_LAYER
   #define HRM_LAYER NUM_ROW_LAYER
@@ -124,14 +131,14 @@
   #define RTHUMB_REACH  &mt ALT_CTL ENTER
   #define RTHUMB_HOME   RTHUMB_TT
   #define RTHUMB_TUCK   &sym_shift_altgr
-#elifdef HT_HOME_ROW_MODS
+#elif defined HT_HOME_ROW_MODS || defined HT_CALLUM_MODS
   #define LTHUMB_TUCK   &EZ_SK(LSHIFT)
   #define LTHUMB_HOME   LTHUMB_HRM
   #define LTHUMB_REACH  &sc HRM_LAYER REACH_TAP
   #define RTHUMB_REACH  &sc HRM_LAYER ENTER
   #define RTHUMB_HOME   RTHUMB_HRM
   #define RTHUMB_TUCK   &sym_shift_altgr
-#elifdef HT_TWO_THUMB_KEYS
+#elif defined HT_TWO_THUMB_KEYS || defined HT_CALLUM_MODS_2TK
   #define LTHUMB_TUCK   &mt LSHIFT REACH_TAP
   #define LTHUMB_HOME   LTHUMB_S34
   #define LTHUMB_REACH  LTHUMB_TUCK

--- a/include/aekeynox/hold_taps.dtsi
+++ b/include/aekeynox/hold_taps.dtsi
@@ -45,7 +45,7 @@
 #define UH3 hrm GUI_OPT
 #define UH4 hrm LSHIFT
 
-#if defined HT_HOME_ROW_MODS || defined HT_TWO_THUMB_KEYS
+#ifdef ENABLE_HOME_ROW_MODS
   #define H1 hrm ALT_CTL
   #define H2 hrm CTL_CMD
   #define H3 hrm GUI_OPT
@@ -75,13 +75,13 @@
   #define NAV_SC &sc
 #endif
 
-#if defined HT_CALLUM_MODS || defined HT_CALLUM_MODS_2TK
+#ifdef CALLUM_NAVIGATION
   #define NAV_LAYER CALLUM_LAYER
   #define NUM_LAYER NUM_ROW_LAYER
   #define HRM_LAYER NUM_ROW_LAYER
   #define S34_LAYER NUM_ROW_LAYER
   #define REACH_TAP ESCAPE
-#elifdef VIM_NAVIGATION
+#elif defined VIM_NAVIGATION
   #define NAV_LAYER VIM_NAV_LAYER
   #define NUM_LAYER NUM_ROW_LAYER
   #define HRM_LAYER NUM_ROW_LAYER

--- a/include/aekeynox/selenium.keymap
+++ b/include/aekeynox/selenium.keymap
@@ -93,11 +93,11 @@
       )>;
     };
 
-    // 5. Callum layer -- one-shot mods on the left hand, inverted T arrow cluster on the right hand
+    // 5. CalTee layer -- one-shot mods on the left hand, inverted T arrow cluster on the right hand
     //                 -- best used along with the NumRow layer
     //                 -- some keyboard shortcuts on the left hand are adjusted to the OS layout (Ergol here)
-    callum_layer: callum_layer {
-      display-name = "Callum";
+    cal_tee_layer: cal_tee_layer {
+      display-name = "CalTee";
       bindings = <SELENIUM_KEYMAP_BINDINGS(
         &trans  ,  &vim_prev    &kp LS(TAB)  &kp TAB      &vim_next     &trans   ,   &kp PG_UP &kp HOME &kp UP   &kp END    &trans  ,  &trans ,
         &trans  ,  &EZ_SK(LSFT) &EZ_SK(LGUI) &EZ_SK(LCTL) &EZ_SK(LALT)  &trans   ,   &kp PG_DN &kp LEFT &kp DOWN &kp RIGHT  &trans  ,  &trans ,

--- a/include/aekeynox/selenium.keymap
+++ b/include/aekeynox/selenium.keymap
@@ -93,7 +93,20 @@
       )>;
     };
 
-    // 5. NumRow layer -- bring the numbers to the homerow, keep shift+numbers for shortcuts and symbols
+    // 5. Callum layer -- one-shot mods on the left hand, inverted T arrow cluster on the right hand
+    //                 -- best used along with the NumRow layer
+    //                 -- some keyboard shortcuts on the left hand are adjusted to the OS layout (Ergol here)
+    callum_layer: callum_layer {
+      display-name = "Callum";
+      bindings = <SELENIUM_KEYMAP_BINDINGS(
+        &trans  ,  &vim_prev    &kp LS(TAB)  &kp TAB      &vim_next     &trans   ,   &kp PG_UP &kp HOME &kp UP   &kp END    &trans  ,  &trans ,
+        &trans  ,  &EZ_SK(LSFT) &EZ_SK(LGUI) &EZ_SK(LCTL) &EZ_SK(LALT)  &trans   ,   &kp PG_DN &kp LEFT &kp DOWN &kp RIGHT  &trans  ,  &trans ,
+        &trans  ,  X_UNDO       X_CUT        X_COPY       X_PASTE       X_REDO   ,   &trans    &trans   &trans   &trans     &trans  ,  &trans ,
+                          &kp CAPS , &sc FN_MEDIA_LAYER DEL , &mo NUM_ROW_LAYER  ,   &trans ,  &mo FN_MEDIA_LAYER , &EZ_LSK(RALT)
+      )>;
+    };
+
+    // 6. NumRow layer -- bring the numbers to the homerow, keep shift+numbers for shortcuts and symbols
     //                 -- space becomes shift+space, which is a no-break space with some OS layouts (e.g. Ergol)
     //                 -- best used along with the VimNav layer
     num_row_layer: num_row_layer {
@@ -106,7 +119,7 @@
       )>;
     };
 
-    // 6. FnMedia layer -- F1..12 pad on the left hand, HRM on the right hand
+    // 7. FnMedia layer -- F1..12 pad on the left hand, HRM on the right hand
     //                  -- reset and bootloader reset on difficult thumb keys
     //                  -- could be completed with other rare keys
     fn_media_layer: fn_media_layer {

--- a/include/aekeynox/settings.h
+++ b/include/aekeynox/settings.h
@@ -66,10 +66,8 @@
 
 // #define HT_NONE
 // #define HT_THUMB_TAPS
-// #define HT_CALLUM_MODS     // (experimental)
 // #define HT_HOME_ROW_MODS   // (default behavior)
 // #define HT_TWO_THUMB_KEYS
-// #define HT_CALLUM_MODS_2TK // (experimental)
 
 // Timing is key! Keep the default value if unsure.
 // This defines how long (in ms) a hold-tap key with the "tap-preferred" flavor
@@ -107,6 +105,12 @@
 // Highly recommended for Vim users, obviously. :-)
 
 // #define VIM_NAVIGATION
+
+// [Experimental]
+// Uncomment the following line to enable the Callum variant of the previous
+// `VIM_NAVIGATION` option. Both options are mutually exclusive.
+
+// #define CALLUM_NAVIGATION
 
 // [Experimental]
 // Uncomment the following line to enable the "mod-hold behavior" on the left

--- a/include/aekeynox/settings.h
+++ b/include/aekeynox/settings.h
@@ -66,7 +66,7 @@
 
 // #define HT_NONE
 // #define HT_THUMB_TAPS
-// #define HT_HOME_ROW_MODS   // (default behavior)
+// #define HT_HOME_ROW_MODS  // (default behavior)
 // #define HT_TWO_THUMB_KEYS
 
 // Timing is key! Keep the default value if unsure.

--- a/include/aekeynox/settings.h
+++ b/include/aekeynox/settings.h
@@ -66,8 +66,10 @@
 
 // #define HT_NONE
 // #define HT_THUMB_TAPS
-// #define HT_HOME_ROW_MODS  // (default behavior)
+// #define HT_CALLUM_MODS     // (experimental)
+// #define HT_HOME_ROW_MODS   // (default behavior)
 // #define HT_TWO_THUMB_KEYS
+// #define HT_CALLUM_MODS_2TK // (experimental)
 
 // Timing is key! Keep the default value if unsure.
 // This defines how long (in ms) a hold-tap key with the "tap-preferred" flavor


### PR DESCRIPTION
Added a callum mods variant / navigation layer. It reuses the same kind of thumb keys then the HRM-Vim config (2 or 3 thumb keys), except the binding for the nav layer (which sends to the callum mods layer).

Hopefully, this acts as a good alternative to advanced users who struggle with home row mods or just generally don’t like them