### PR TITLE
feat: implement fancy dead-key support for emulations

### DIFF
--- a/include/aekeynox/aliases/azerty.h
+++ b/include/aekeynox/aliases/azerty.h
@@ -122,6 +122,51 @@
 
 #define SA(key) RS(RA(key))
 
+#ifdef ENABLE_FANCY_DEAD_KEYS
+  / {
+    behaviors {
+      crc: circumflex_accent {
+        compatible = "zmk,behavior-dead-key";
+        #binding-cells = <1>;
+        dead-key = <CARET>;
+      };
+
+      dia: diaeresis_accent {
+        compatible = "zmk,behavior-dead-key";
+        #binding-cells = <1>;
+        dead-key = <DQT>;
+      };
+
+      tld: tilde_accent {
+        compatible = "zmk,behavior-dead-key";
+        #binding-cells = <1>;
+        #ifdef MACOS
+          dead-key = <RA(N)>;
+        #else
+          dead-key = <RA(N2)>;
+        #endif
+      };
+    };
+  };
+  #define D_CIRCUMFLEX &crc
+  #define D_DIAERESIS  &dia
+  #ifdef LINUX
+    #define D_TILDE &kp
+  #else
+    #define D_TILDE &tld
+  #endif
+#else
+  #define D_CIRCUMFLEX &digraph LBKT
+  #define D_DIAERESIS  &digraph LBRC
+  #ifdef LINUX
+    #define D_TILDE &kp
+  #elif defined MACOS
+    #define D_TILDE &digraph RA(N)
+  #else
+    #define D_TILDE &digraph RA(N2)
+  #endif
+#endif
+
 // lowercase: é à è ù ç
 #define C_EACU &kp N2  // é
 #define C_AGRV &kp N0  // à
@@ -165,7 +210,6 @@
 #define SC_YCRC D_CIRCUMFLEX RS(Y) // Ŷ
 
 // diaeresis
-#define D_DIAERESIS &digraph LBRC
 #define  C_ADIA D_DIAERESIS A     // ä
 #define SC_ADIA D_DIAERESIS RS(A) // Ä
 #define  C_EDIA D_DIAERESIS E     // ë
@@ -206,13 +250,6 @@
   #define  C_SZ &digraph S S
 #endif
 
-#ifdef LINUX
-  #define D_TILDE &kp
-#elifdef MACOS
-  #define D_TILDE &digraph RA(N)
-#else
-  #define D_TILDE &digraph RA(N2)
-#endif
 #define  C_NTLD D_TILDE N     // ñ
 #define SC_NTLD D_TILDE LS(N) // Ñ
 

--- a/include/aekeynox/aliases/azerty.h
+++ b/include/aekeynox/aliases/azerty.h
@@ -151,32 +151,33 @@
 #endif
 
 // circumflex accent
-#define  C_ACRC &digraph LBKT Q     // â
-#define SC_ACRC &digraph LBKT RS(Q) // Â
-#define  C_ECRC &digraph LBKT E     // ê
-#define SC_ECRC &digraph LBKT RS(E) // Ê
-#define  C_ICRC &digraph LBKT I     // î
-#define SC_ICRC &digraph LBKT RS(I) // Î
-#define  C_OCRC &digraph LBKT O     // ô
-#define SC_OCRC &digraph LBKT RS(O) // Ô
-#define  C_UCRC &digraph LBKT U     // û
-#define SC_UCRC &digraph LBKT RS(U) // Û
-#define  C_YCRC &digraph LBKT Y     // ŷ
-#define SC_YCRC &digraph LBKT RS(Y) // Ŷ
+#define  C_ACRC D_CIRCUMFLEX Q     // â
+#define SC_ACRC D_CIRCUMFLEX RS(Q) // Â
+#define  C_ECRC D_CIRCUMFLEX E     // ê
+#define SC_ECRC D_CIRCUMFLEX RS(E) // Ê
+#define  C_ICRC D_CIRCUMFLEX I     // î
+#define SC_ICRC D_CIRCUMFLEX RS(I) // Î
+#define  C_OCRC D_CIRCUMFLEX O     // ô
+#define SC_OCRC D_CIRCUMFLEX RS(O) // Ô
+#define  C_UCRC D_CIRCUMFLEX U     // û
+#define SC_UCRC D_CIRCUMFLEX RS(U) // Û
+#define  C_YCRC D_CIRCUMFLEX Y     // ŷ
+#define SC_YCRC D_CIRCUMFLEX RS(Y) // Ŷ
 
 // diaeresis
-#define  C_ADIA &digraph LBRC A     // ä
-#define SC_ADIA &digraph LBRC RS(A) // Ä
-#define  C_EDIA &digraph LBRC E     // ë
-#define SC_EDIA &digraph LBRC RS(E) // Ë
-#define  C_IDIA &digraph LBRC I     // ï
-#define SC_IDIA &digraph LBRC RS(I) // Ï
-#define  C_ODIA &digraph LBRC O     // ö
-#define SC_ODIA &digraph LBRC RS(O) // Ö
-#define  C_UDIA &digraph LBRC U     // ü
-#define SC_UDIA &digraph LBRC RS(U) // Ü
-#define  C_YDIA &digraph LBRC Y     // ÿ
-#define SC_YDIA &digraph LBRC RS(Y) // Ÿ
+#define D_DIAERESIS &digraph LBRC
+#define  C_ADIA D_DIAERESIS A     // ä
+#define SC_ADIA D_DIAERESIS RS(A) // Ä
+#define  C_EDIA D_DIAERESIS E     // ë
+#define SC_EDIA D_DIAERESIS RS(E) // Ë
+#define  C_IDIA D_DIAERESIS I     // ï
+#define SC_IDIA D_DIAERESIS RS(I) // Ï
+#define  C_ODIA D_DIAERESIS O     // ö
+#define SC_ODIA D_DIAERESIS RS(O) // Ö
+#define  C_UDIA D_DIAERESIS U     // ü
+#define SC_UDIA D_DIAERESIS RS(U) // Ü
+#define  C_YDIA D_DIAERESIS Y     // ÿ
+#define SC_YDIA D_DIAERESIS RS(Y) // Ÿ
 
 // other special letters: œ, æ, ß, ñ
 #ifdef LINUX
@@ -204,16 +205,16 @@
   #define SC_AE &digraph LS(Q) LS(E)
   #define  C_SZ &digraph S S
 #endif
+
 #ifdef LINUX
-  #define  C_NTLD &kp N     // XXX
-  #define SC_NTLD &kp LS(N) // XXX
+  #define D_TILDE &kp
 #elifdef MACOS
-  #define  C_NTLD &digraph RA(N) N     // ñ
-  #define SC_NTLD &digraph RA(N) LS(N) // Ñ
+  #define D_TILDE &digraph RA(N)
 #else
-  #define  C_NTLD &digraph RA(N2) N     // ñ
-  #define SC_NTLD &digraph RA(N2) LS(N) // ñ
+  #define D_TILDE &digraph RA(N2)
 #endif
+#define  C_NTLD D_TILDE N     // ñ
+#define SC_NTLD D_TILDE LS(N) // Ñ
 
 // quote signs
 #ifdef LINUX

--- a/include/aekeynox/aliases/qwerty_intl.h
+++ b/include/aekeynox/aliases/qwerty_intl.h
@@ -70,8 +70,54 @@
 
 #define SA(key) RS(RA(key))
 
+#ifdef ENABLE_FANCY_DEAD_KEYS
+  / {
+    behaviors {
+      acu: acute_accent {
+        compatible = "zmk,behavior-dead-key";
+        #binding-cells = <1>;
+        dead-key = <SQT>;
+      };
+
+      grv: grave_accent {
+        compatible = "zmk,behavior-dead-key";
+        #binding-cells = <1>;
+        dead-key = <GRAVE>;
+      };
+
+      crc: circumflex_accent {
+        compatible = "zmk,behavior-dead-key";
+        #binding-cells = <1>;
+        dead-key = <CARET>;
+      };
+
+      dia: diaeresis_accent {
+        compatible = "zmk,behavior-dead-key";
+        #binding-cells = <1>;
+        dead-key = <DQT>;
+      };
+
+      tld: tilde_accent {
+        compatible = "zmk,behavior-dead-key";
+        #binding-cells = <1>;
+        dead-key = <TILDE>;
+      };
+    };
+  };
+  #define D_ACUTE      &acu
+  #define D_GRAVE      &grv
+  #define D_CIRCUMFLEX &crc
+  #define D_DIAERESIS  &dia
+  #define D_TILDE      &tld
+#else
+  #define D_ACUTE      &digraph SQT
+  #define D_GRAVE      &digraph GRAVE
+  #define D_CIRCUMFLEX &digraph CARET
+  #define D_DIAERESIS  &digraph DQT
+  #define D_TILDE      &digraph TILDE
+#endif
+
 // acute accent
-#define D_ACUTE &digraph SQT
 #define  C_AACU D_ACUTE A     // á
 #define SC_AACU D_ACUTE RS(A) // Á
 #define  C_EACU D_ACUTE E     // é
@@ -95,7 +141,6 @@
 #endif
 
 // grave accent
-#define D_GRAVE &digraph GRAVE
 #define  C_AGRV D_GRAVE A     // à
 #define SC_AGRV D_GRAVE RS(A) // À
 #define  C_EGRV D_GRAVE E     // è
@@ -124,7 +169,6 @@
 #define SC_YCRC D_CIRCUMFLEX RS(Y) // Ŷ
 
 // diaeresis
-#define D_DIAERESIS &digraph DQT
 #define  C_ADIA D_DIAERESIS A     // ä
 #define SC_ADIA D_DIAERESIS RS(A) // Ä
 #define  C_EDIA D_DIAERESIS E     // ë
@@ -139,7 +183,6 @@
 #define SC_YDIA D_DIAERESIS RS(Y) // Ÿ
 
 // tilde
-#define D_TILDE &digraph TILDE
 #define  C_ATLD D_TILDE A     // ã
 #define SC_ATLD D_TILDE RS(A) // Ã
 #define  C_ETLD D_TILDE E     // ẽ

--- a/include/aekeynox/aliases/qwerty_intl.h
+++ b/include/aekeynox/aliases/qwerty_intl.h
@@ -71,85 +71,89 @@
 #define SA(key) RS(RA(key))
 
 // acute accent
-#define  C_AACU &digraph SQT A     // á
-#define SC_AACU &digraph SQT RS(A) // Á
-#define  C_EACU &digraph SQT E     // é
-#define SC_EACU &digraph SQT RS(E) // É
-#define  C_IACU &digraph SQT I     // í
-#define SC_IACU &digraph SQT RS(I) // Í
-#define  C_OACU &digraph SQT O     // ó
-#define SC_OACU &digraph SQT RS(O) // Ó
-#define  C_UACU &digraph SQT U     // ú
-#define SC_UACU &digraph SQT RS(U) // Ú
-#define  C_YACU &digraph SQT Y     // ý
-#define SC_YACU &digraph SQT RS(Y) // Ý
+#define D_ACUTE &digraph SQT
+#define  C_AACU D_ACUTE A     // á
+#define SC_AACU D_ACUTE RS(A) // Á
+#define  C_EACU D_ACUTE E     // é
+#define SC_EACU D_ACUTE RS(E) // É
+#define  C_IACU D_ACUTE I     // í
+#define SC_IACU D_ACUTE RS(I) // Í
+#define  C_OACU D_ACUTE O     // ó
+#define SC_OACU D_ACUTE RS(O) // Ó
+#define  C_UACU D_ACUTE U     // ú
+#define SC_UACU D_ACUTE RS(U) // Ú
+#define  C_YACU D_ACUTE Y     // ý
+#define SC_YACU D_ACUTE RS(Y) // Ý
 
 // cedilla
 #ifdef MACOS
-  #define  C_CCDL &digraph SQT C        // ç
-  #define SC_CCDL &digraph SQT RS(C)    // ç
+  #define  C_CCDL D_ACUTE C        // ç
+  #define SC_CCDL D_ACUTE RS(C)    // ç
 #else
   #define  C_CCDL &kp RA(COMMA)  // ç
   #define SC_CCDL &kp SA(COMMA)  // ç
 #endif
 
 // grave accent
-#define  C_AGRV &digraph GRAVE A     // à
-#define SC_AGRV &digraph GRAVE RS(A) // À
-#define  C_EGRV &digraph GRAVE E     // è
-#define SC_EGRV &digraph GRAVE RS(E) // È
-#define  C_IGRV &digraph GRAVE I     // ì
-#define SC_IGRV &digraph GRAVE RS(I) // Ì
-#define  C_OGRV &digraph GRAVE O     // ò
-#define SC_OGRV &digraph GRAVE RS(O) // Ò
-#define  C_UGRV &digraph GRAVE U     // ù
-#define SC_UGRV &digraph GRAVE RS(U) // Ù
-#define  C_YGRV &digraph GRAVE Y     // ỳ
-#define SC_YGRV &digraph GRAVE RS(Y) // Ỳ
+#define D_GRAVE &digraph GRAVE
+#define  C_AGRV D_GRAVE A     // à
+#define SC_AGRV D_GRAVE RS(A) // À
+#define  C_EGRV D_GRAVE E     // è
+#define SC_EGRV D_GRAVE RS(E) // È
+#define  C_IGRV D_GRAVE I     // ì
+#define SC_IGRV D_GRAVE RS(I) // Ì
+#define  C_OGRV D_GRAVE O     // ò
+#define SC_OGRV D_GRAVE RS(O) // Ò
+#define  C_UGRV D_GRAVE U     // ù
+#define SC_UGRV D_GRAVE RS(U) // Ù
+#define  C_YGRV D_GRAVE Y     // ỳ
+#define SC_YGRV D_GRAVE RS(Y) // Ỳ
 
 // circumflex accent
-#define  C_ACRC &digraph CARET A     // â
-#define SC_ACRC &digraph CARET RS(A) // Â
-#define  C_ECRC &digraph CARET E     // ê
-#define SC_ECRC &digraph CARET RS(E) // Ê
-#define  C_ICRC &digraph CARET I     // î
-#define SC_ICRC &digraph CARET RS(I) // Î
-#define  C_OCRC &digraph CARET O     // ô
-#define SC_OCRC &digraph CARET RS(O) // Ô
-#define  C_UCRC &digraph CARET U     // û
-#define SC_UCRC &digraph CARET RS(U) // Û
-#define  C_YCRC &digraph CARET Y     // ŷ
-#define SC_YCRC &digraph CARET RS(Y) // Ŷ
+#define  C_ACRC D_CIRCUMFLEX A     // â
+#define SC_ACRC D_CIRCUMFLEX RS(A) // Â
+#define  C_ECRC D_CIRCUMFLEX E     // ê
+#define SC_ECRC D_CIRCUMFLEX RS(E) // Ê
+#define  C_ICRC D_CIRCUMFLEX I     // î
+#define SC_ICRC D_CIRCUMFLEX RS(I) // Î
+#define  C_OCRC D_CIRCUMFLEX O     // ô
+#define SC_OCRC D_CIRCUMFLEX RS(O) // Ô
+#define  C_UCRC D_CIRCUMFLEX U     // û
+#define SC_UCRC D_CIRCUMFLEX RS(U) // Û
+#define  C_YCRC D_CIRCUMFLEX Y     // ŷ
+#define SC_YCRC D_CIRCUMFLEX RS(Y) // Ŷ
 
 // diaeresis
-#define  C_ADIA &digraph DQT A     // ä
-#define SC_ADIA &digraph DQT RS(A) // Ä
-#define  C_EDIA &digraph DQT E     // ë
-#define SC_EDIA &digraph DQT RS(E) // Ë
-#define  C_IDIA &digraph DQT I     // ï
-#define SC_IDIA &digraph DQT RS(I) // Ï
-#define  C_ODIA &digraph DQT O     // ö
-#define SC_ODIA &digraph DQT RS(O) // Ö
-#define  C_UDIA &digraph DQT U     // ü
-#define SC_UDIA &digraph DQT RS(U) // Ü
-#define  C_YDIA &digraph DQT Y     // ÿ
-#define SC_YDIA &digraph DQT RS(Y) // Ÿ
+#define D_DIAERESIS &digraph DQT
+#define  C_ADIA D_DIAERESIS A     // ä
+#define SC_ADIA D_DIAERESIS RS(A) // Ä
+#define  C_EDIA D_DIAERESIS E     // ë
+#define SC_EDIA D_DIAERESIS RS(E) // Ë
+#define  C_IDIA D_DIAERESIS I     // ï
+#define SC_IDIA D_DIAERESIS RS(I) // Ï
+#define  C_ODIA D_DIAERESIS O     // ö
+#define SC_ODIA D_DIAERESIS RS(O) // Ö
+#define  C_UDIA D_DIAERESIS U     // ü
+#define SC_UDIA D_DIAERESIS RS(U) // Ü
+#define  C_YDIA D_DIAERESIS Y     // ÿ
+#define SC_YDIA D_DIAERESIS RS(Y) // Ÿ
 
 // tilde
-#define  C_ATLD &digraph TILDE A     // ã
-#define SC_ATLD &digraph TILDE RS(A) // Ã
-#define  C_ETLD &digraph TILDE E     // ẽ
-#define SC_ETLD &digraph TILDE RS(E) // Ẽ
-#define  C_ITLD &digraph TILDE I     // ĩ
-#define SC_ITLD &digraph TILDE RS(I) // Ĩ
-#define  C_OTLD &digraph TILDE O     // õ
-#define SC_OTLD &digraph TILDE RS(O) // Õ
-#define  C_UTLD &digraph TILDE U     // ũ
-#define SC_UTLD &digraph TILDE RS(U) // Ũ
-#define  C_YTLD &digraph TILDE Y     // ỹ
-#define SC_YTLD &digraph TILDE RS(Y) // Ỹ
-#define  C_NTLD &digraph TILDE N     // ñ
-#define SC_NTLD &digraph TILDE RS(N) // Ñ
+#define D_TILDE &digraph TILDE
+#define  C_ATLD D_TILDE A     // ã
+#define SC_ATLD D_TILDE RS(A) // Ã
+#define  C_ETLD D_TILDE E     // ẽ
+#define SC_ETLD D_TILDE RS(E) // Ẽ
+#define  C_ITLD D_TILDE I     // ĩ
+#define SC_ITLD D_TILDE RS(I) // Ĩ
+#define  C_OTLD D_TILDE O     // õ
+#define SC_OTLD D_TILDE RS(O) // Õ
+#define  C_UTLD D_TILDE U     // ũ
+#define SC_UTLD D_TILDE RS(U) // Ũ
+#define  C_YTLD D_TILDE Y     // ỹ
+#define SC_YTLD D_TILDE RS(Y) // Ỹ
+#define  C_NTLD D_TILDE N     // ñ
+#define SC_NTLD D_TILDE RS(N) // Ñ
 
 // spectal letters
 #ifdef LINUX

--- a/include/aekeynox/emulations/ergol.dtsi
+++ b/include/aekeynox/emulations/ergol.dtsi
@@ -10,6 +10,12 @@
   };
 };
 
+#ifdef ENABLE_FANCY_DEAD_KEYS
+  #define ODK_SHIFT_KEY &EZ_SK(LSHIFT)
+#else
+  #define ODK_SHIFT_KEY &EZ_SL(ODK_SHIFT_LAYER)
+#endif
+
 #include "nbsp.dtsi"
 #include "ergol_num.dtsi"
 
@@ -63,7 +69,7 @@
         &trans  ,  C_ACRC  C_CCDL  C_OE    C_OCRC  &trans   ,   &trans  C_MICRO S_UNDER K_DIA   C_UCRC  ,  &trans ,
         &trans  ,  C_AGRV  C_EACU  C_EGRV  C_ECRC  C_NTLD   ,   S_LPAR  S_RPAR  C_ICRC  C_IDIA  C_UGRV  ,  &trans ,
         &trans  ,  C_AE    C_SZ    S_MINUS C_NDASH C_MDASH  ,   C_ELLIP C_MDOT  &trans  C_BLLT  &trans  ,  &trans ,
-                &EZ_SL(ODK_SHIFT_LAYER) , C_APOS , &trans   ,   &trans , C_APOS , &trans
+                          ODK_SHIFT_KEY , C_APOS , &trans   ,   &trans , C_APOS , &trans
       )>;
     };
 

--- a/include/aekeynox/emulations/qwerty_lafayette.dtsi
+++ b/include/aekeynox/emulations/qwerty_lafayette.dtsi
@@ -10,6 +10,12 @@
   };
 };
 
+#ifdef ENABLE_FANCY_DEAD_KEYS
+  #define ODK_SHIFT_KEY &EZ_SK(LSHIFT)
+#else
+  #define ODK_SHIFT_KEY &EZ_SL(ODK_SHIFT_LAYER)
+#endif
+
 #include "nbsp.dtsi"
 #include "ergol_num.dtsi"
 
@@ -63,7 +69,7 @@
         &trans  ,  C_AE    C_EACU  C_EGRV  C_OCRC  &trans   ,   &trans  C_UGRV  C_IDIA  C_OE    &trans  ,  &trans ,
         &trans  ,  C_AGRV  C_SZ    C_ECRC  S_MINUS C_NDASH  ,   &trans  C_UCRC  C_ICRC  C_OCRC  K_DIA   ,  &trans ,
         &trans  ,  C_ACRC  C_MULT  C_CCDL  S_UNDER C_MDASH  ,   C_NTLD  C_MICRO C_MDOT  C_ELLIP &trans  ,  &trans ,
-                &EZ_SL(ODK_SHIFT_LAYER) , C_APOS , &trans   ,   &trans , C_APOS , &trans
+                          ODK_SHIFT_KEY , C_APOS , &trans   ,   &trans , C_APOS , &trans
       )>;
     };
 


### PR DESCRIPTION
It’s been waiting for a while now, but I’ve finally added fancy dead-keys support for both the ergol and lafayette emulations. Still needs proper testing on my end, but this should be good enough to start a review