### PR TITLE
feat: option to set alpha keys on outer columns

### DIFF
--- a/include/aekeynox/emulations/colemak.dtsi
+++ b/include/aekeynox/emulations/colemak.dtsi
@@ -1,8 +1,8 @@
 &base_layer {
   bindings = <SELENIUM_KEYMAP_BINDINGS(
-    &kp TAB    ,  &kp Q  &kp W  &kp F  &kp P  &kp G   ,   &kp J  &kp L  &kp U     &kp Y   &kp SEMI  ,  &kp BACKSPACE ,
-    &kp ESCAPE ,  &H4 A  &H3 R  &H2 S  &H1 T  &kp D   ,   &kp H  &H1 N  &H2 E     &H3 I   &H4 O     ,  &kp ENTER     ,
-    &kp LSHIFT ,  &kp Z  &kp X  &kp C  &kp V  &kp B   ,   &kp K  &kp M  &kp COMMA &kp DOT &kp FSLH  ,  &kp RSHIFT    ,
+    &kp LTOP   ,  &kp Q  &kp W  &kp F  &kp P  &kp G   ,   &kp J  &kp L  &kp U     &kp Y   &kp SEMI  ,  &kp RTOP   ,
+    &kp LHOME  ,  &H4 A  &H3 R  &H2 S  &H1 T  &kp D   ,   &kp H  &H1 N  &H2 E     &H3 I   &H4 O     ,  &kp RHOME  ,
+    &kp LSHIFT ,  &kp Z  &kp X  &kp C  &kp V  &kp B   ,   &kp K  &kp M  &kp COMMA &kp DOT &kp FSLH  ,  &kp RSHIFT ,
            LTHUMB_TUCK , LTHUMB_HOME , LTHUMB_REACH   ,   RTHUMB_REACH , RTHUMB_HOME , RTHUMB_TUCK
   )>;
 };

--- a/include/aekeynox/emulations/colemak_dh.dtsi
+++ b/include/aekeynox/emulations/colemak_dh.dtsi
@@ -1,8 +1,8 @@
 &base_layer {
   bindings = <SELENIUM_KEYMAP_BINDINGS(
-    &kp TAB    ,  &kp Q  &kp W  &kp F  &kp P  &kp B   ,   &kp J  &kp L  &kp U     &kp Y   &kp SEMI  ,  &kp BACKSPACE ,
-    &kp ESCAPE ,  &H4 A  &H3 R  &H2 S  &H1 T  &kp G   ,   &kp M  &H1 N  &H2 E     &H3 I   &H4 O     ,  &kp ENTER     ,
-    &kp LSHIFT ,  &kp Z  &kp X  &kp C  &kp D  &kp V   ,   &kp K  &kp H  &kp COMMA &kp DOT &kp FSLH  ,  &kp RSHIFT    ,
+    &kp LTOP   ,  &kp Q  &kp W  &kp F  &kp P  &kp B   ,   &kp J  &kp L  &kp U     &kp Y   &kp SEMI  ,  &kp RTOP   ,
+    &kp LHOME  ,  &H4 A  &H3 R  &H2 S  &H1 T  &kp G   ,   &kp M  &H1 N  &H2 E     &H3 I   &H4 O     ,  &kp RHOME  ,
+    &kp LSHIFT ,  &kp Z  &kp X  &kp C  &kp D  &kp V   ,   &kp K  &kp H  &kp COMMA &kp DOT &kp FSLH  ,  &kp RSHIFT ,
            LTHUMB_TUCK , LTHUMB_HOME , LTHUMB_REACH   ,   RTHUMB_REACH , RTHUMB_HOME , RTHUMB_TUCK
   )>;
 };

--- a/include/aekeynox/emulations/dvorak.dtsi
+++ b/include/aekeynox/emulations/dvorak.dtsi
@@ -4,6 +4,6 @@
     &kp LTOP   ,  &kp SQT  &kp COMMA &kp DOT &kp P  &kp Y   ,   &kp F  &kp G  &kp C  &kp R  &kp L  ,  &kp RTOP   ,
     &kp LHOME  ,  &H4 A    &H3 O     &H2 E   &H1 U  &kp I   ,   &kp D  &H1 H  &H2 T  &H3 N  &H4 S  ,  &kp RHOME  ,
     &kp LSHIFT ,  &kp SEMI &kp Q     &kp J   &kp K  &kp X   ,   &kp B  &kp M  &kp W  &kp V  &kp Z  ,  &kp RSHIFT ,
-             LTHUMB_TUCK , LTHUMB_HOME , LTHUMB_REACH   ,   RTHUMB_REACH , RTHUMB_HOME , RTHUMB_TUCK
+                 LTHUMB_TUCK , LTHUMB_HOME , LTHUMB_REACH   ,   RTHUMB_REACH , RTHUMB_HOME , RTHUMB_TUCK
   )>;
 };

--- a/include/aekeynox/emulations/dvorak.dtsi
+++ b/include/aekeynox/emulations/dvorak.dtsi
@@ -1,9 +1,9 @@
 &base_layer {
   display-name = "Base";
   bindings = <SELENIUM_KEYMAP_BINDINGS(
-    &kp TAB    ,  &kp SQT  &kp COMMA &kp DOT &kp P  &kp Y   ,   &kp F  &kp G  &kp C  &kp R  &kp L  ,  &kp BACKSPACE ,
-    &kp ESCAPE ,  &H4 A    &H3 O     &H2 E   &H1 U  &kp I   ,   &kp D  &H1 H  &H2 T  &H3 N  &H4 S  ,  &kp ENTER     ,
-    &kp LSHIFT ,  &kp SEMI &kp Q     &kp J   &kp K  &kp X   ,   &kp B  &kp M  &kp W  &kp V  &kp Z  ,  &kp RSHIFT    ,
+    &kp LTOP   ,  &kp SQT  &kp COMMA &kp DOT &kp P  &kp Y   ,   &kp F  &kp G  &kp C  &kp R  &kp L  ,  &kp RTOP   ,
+    &kp LHOME  ,  &H4 A    &H3 O     &H2 E   &H1 U  &kp I   ,   &kp D  &H1 H  &H2 T  &H3 N  &H4 S  ,  &kp RHOME  ,
+    &kp LSHIFT ,  &kp SEMI &kp Q     &kp J   &kp K  &kp X   ,   &kp B  &kp M  &kp W  &kp V  &kp Z  ,  &kp RSHIFT ,
              LTHUMB_TUCK , LTHUMB_HOME , LTHUMB_REACH   ,   RTHUMB_REACH , RTHUMB_HOME , RTHUMB_TUCK
   )>;
 };

--- a/include/aekeynox/emulations/ergol.dtsi
+++ b/include/aekeynox/emulations/ergol.dtsi
@@ -23,10 +23,10 @@
   &base_layer {
     display-name = "Base";
     bindings = <SELENIUM_KEYMAP_BINDINGS(
-      &kp TAB    ,  &kp A  &kp C  &kp O  &kp P  &kp Z   ,   &kp J  &kp SEMI &kp D  &apos  &kp Y  ,  &kp BACKSPACE ,
-      &kp ESCAPE ,  &H4 Q  &H3 S  &H2 E  &H1 N  &kp F   ,   &kp L  &H1 R    &H2 T  &H3 I  &H4 U  ,  &kp ENTER     ,
-      &kp LSHIFT ,  &kp W  &kp X  &dash  &kp V  &kp B   ,   &dot   &kp H    &kp G  &comma &kp K  ,  &kp RSHIFT    ,
-         LTHUMB_TUCK , LTHUMB_HOME , LTHUMB_REACH   ,   RTHUMB_REACH , RTHUMB_HOME , RTHUMB_TUCK
+      &kp LTOP   ,  &kp A  &kp C  &kp O  &kp P  &kp Z   ,   &kp J  &kp SEMI &kp D  &apos  &kp Y  ,  &kp RTOP   ,
+      &kp LHOME  ,  &H4 Q  &H3 S  &H2 E  &H1 N  &kp F   ,   &kp L  &H1 R    &H2 T  &H3 I  &H4 U  ,  &kp RHOME  ,
+      &kp LSHIFT ,  &kp W  &kp X  &dash  &kp V  &kp B   ,   &dot   &kp H    &kp G  &comma &kp K  ,  &kp RSHIFT ,
+             LTHUMB_TUCK , LTHUMB_HOME , LTHUMB_REACH   ,   RTHUMB_REACH , RTHUMB_HOME , RTHUMB_TUCK
     )>;
   };
   #define K_DIA &kp LBRC // diaeresis
@@ -36,10 +36,10 @@
   &base_layer {
     display-name = "Base";
     bindings = <SELENIUM_KEYMAP_BINDINGS(
-      &none  ,  &kp Q  &kp C  &kp O  &kp P  &kp W   ,   &kp J  &kp M  &kp D  &apos  &kp Y  ,  &none ,
-      &none  ,  &H4 A  &H3 S  &H2 E  &H1 N  &kp F   ,   &kp L  &H1 R  &H2 T  &H3 I  &H4 U  ,  &none ,
-      &none  ,  &kp Z  &kp X  &dash  &kp V  &kp B   ,   &dot   &kp H  &kp G  &comma &kp K  ,  &none ,
-         LTHUMB_TUCK , LTHUMB_HOME , LTHUMB_REACH   ,   RTHUMB_REACH , RTHUMB_HOME , RTHUMB_TUCK
+      &kp LTOP   ,  &kp Q  &kp C  &kp O  &kp P  &kp W   ,   &kp J  &kp M  &kp D  &apos  &kp Y  ,  &kp RTOP   ,
+      &kp LHOME  ,  &H4 A  &H3 S  &H2 E  &H1 N  &kp F   ,   &kp L  &H1 R  &H2 T  &H3 I  &H4 U  ,  &kp RHOME  ,
+      &kp LSHIFT ,  &kp Z  &kp X  &dash  &kp V  &kp B   ,   &dot   &kp H  &kp G  &comma &kp K  ,  &kp RSHIFT ,
+             LTHUMB_TUCK , LTHUMB_HOME , LTHUMB_REACH   ,   RTHUMB_REACH , RTHUMB_HOME , RTHUMB_TUCK
     )>;
   };
   #define K_DIA &kp DQT // diaeresis

--- a/include/aekeynox/emulations/ergol_num.dtsi
+++ b/include/aekeynox/emulations/ergol_num.dtsi
@@ -2,10 +2,10 @@
 &num_row_layer {
   display-name = "NumRow";
   bindings = <SELENIUM_KEYMAP_BINDINGS(
-    &kp TAB    ,  C_EURO  C_LGQT  C_RGQT  S_DLLR  S_PRCNT  ,   S_CARET S_AMPS  S_STAR  S_LPAR  S_RPAR  ,  &kp BACKSPACE ,
-    &kp ESCAPE ,  S_N1    S_N2    S_N3    S_N4    S_N5     ,   S_N6    S_N7    S_N8    S_N9    S_N0    ,  &kp ENTER     ,
-    &kp LSHIFT ,  C_LODQT C_LDQT  C_RDQT  C_CENT  C_DEG    ,   S_MINUS S_COMMA S_DOT   S_COLON S_FSLH  ,  &kp RSHIFT    ,
-                                &trans , C_NBSP , &trans   ,   &trans , C_NBSP , &trans
+    &trans  ,  C_EURO  C_LGQT  C_RGQT  S_DLLR  S_PRCNT  ,   S_CARET S_AMPS  S_STAR  S_LPAR  S_RPAR  ,  &trans ,
+    &trans  ,  S_N1    S_N2    S_N3    S_N4    S_N5     ,   S_N6    S_N7    S_N8    S_N9    S_N0    ,  &trans ,
+    &trans  ,  C_LODQT C_LDQT  C_RDQT  C_CENT  C_DEG    ,   S_MINUS S_COMMA S_DOT   S_COLON S_FSLH  ,  &trans ,
+                             &trans , C_NBSP , &trans   ,   &trans , C_NBSP , &trans
   )>;
 };
 

--- a/include/aekeynox/emulations/qwerty_lafayette.dtsi
+++ b/include/aekeynox/emulations/qwerty_lafayette.dtsi
@@ -23,10 +23,10 @@
   &base_layer {
     display-name = "Base";
     bindings = <SELENIUM_KEYMAP_BINDINGS(
-      &kp TAB    ,  &kp A  &kp Z  &kp E  &kp R  &kp T   ,   &kp Y  &kp U    &kp I  &kp O  &kp P   ,  &kp BACKSPACE ,
-      &kp ESCAPE ,  &H4 Q  &H3 S  &H2 D  &H1 F  &kp G   ,   &kp H  &H1 J    &H2 K  &H3 L  &apos   ,  &kp ENTER     ,
-      &kp LSHIFT ,  &kp W  &kp X  &kp C  &kp V  &kp B   ,   &kp N  &kp SEMI &comma &dot   &slash  ,  &kp RSHIFT    ,
-         LTHUMB_TUCK , LTHUMB_HOME , LTHUMB_REACH   ,   RTHUMB_REACH , RTHUMB_HOME , RTHUMB_TUCK
+      &kp LTOP   ,  &kp A  &kp Z  &kp E  &kp R  &kp T   ,   &kp Y  &kp U    &kp I  &kp O  &kp P   ,  &kp RTOP   ,
+      &kp LHOME  ,  &H4 Q  &H3 S  &H2 D  &H1 F  &kp G   ,   &kp H  &H1 J    &H2 K  &H3 L  &apos   ,  &kp RHOME  ,
+      &kp LSHIFT ,  &kp W  &kp X  &kp C  &kp V  &kp B   ,   &kp N  &kp SEMI &comma &dot   &slash  ,  &kp RSHIFT ,
+             LTHUMB_TUCK , LTHUMB_HOME , LTHUMB_REACH   ,   RTHUMB_REACH , RTHUMB_HOME , RTHUMB_TUCK
     )>;
   };
   #define K_DIA &kp LBRC // diaeresis
@@ -36,10 +36,10 @@
   &base_layer {
     display-name = "Base";
     bindings = <SELENIUM_KEYMAP_BINDINGS(
-      &kp TAB    ,  &kp Q  &kp W  &kp E  &kp R  &kp T   ,   &kp Y  &kp U  &kp I  &kp O  &kp P     ,  &kp BACKSPACE ,
-      &kp ESCAPE ,  &H4 A  &H3 S  &H2 D  &H1 F  &kp G   ,   &kp H  &H1 J  &H2 K  &H3 L  &apos     ,  &kp ENTER     ,
-      &kp LSHIFT ,  &kp Z  &kp X  &kp C  &kp V  &kp B   ,   &kp N  &kp M  &comma &dot   &kp FSLH  ,  &kp RSHIFT    ,
-         LTHUMB_TUCK , LTHUMB_HOME , LTHUMB_REACH   ,   RTHUMB_REACH , RTHUMB_HOME , RTHUMB_TUCK
+      &kp LTOP   ,  &kp Q  &kp W  &kp E  &kp R  &kp T   ,   &kp Y  &kp U  &kp I  &kp O  &kp P     ,  &kp RTOP   ,
+      &kp LHOME  ,  &H4 A  &H3 S  &H2 D  &H1 F  &kp G   ,   &kp H  &H1 J  &H2 K  &H3 L  &apos     ,  &kp RHOME  ,
+      &kp LSHIFT ,  &kp Z  &kp X  &kp C  &kp V  &kp B   ,   &kp N  &kp M  &comma &dot   &kp FSLH  ,  &kp RSHIFT ,
+             LTHUMB_TUCK , LTHUMB_HOME , LTHUMB_REACH   ,   RTHUMB_REACH , RTHUMB_HOME , RTHUMB_TUCK
     )>;
   };
   #define K_DIA &kp DQT // diaeresis

--- a/include/aekeynox/extra_layers/azerty.dtsi
+++ b/include/aekeynox/extra_layers/azerty.dtsi
@@ -4,9 +4,9 @@
 &base_layer {
   display-name = "Base";
   bindings = <SELENIUM_KEYMAP_BINDINGS(
-    &kp TAB     ,  &kp Q &kp W &kp E &kp R &kp T  ,  &kp Y  &kp U  &kp I     &kp O   &kp P     ,  &kp BACKSPACE  ,
-    &kp ESCAPE  ,  &H4 A &H3 S &H2 D &H1 F &kp G  ,  &kp H  &H1 J  &H2 K     &H3 L   &H4 SEMI  ,  &dead_key      ,
-    &kp LSHIFT  ,  &kp Z &kp X &kp C &kp V &kp B  ,  &kp N  &kp M  &kp COMMA &kp DOT &kp FSLH  ,  &kp RSHIFT     ,
+    &kp LTOP    ,  &kp Q &kp W &kp E &kp R &kp T  ,  &kp Y  &kp U  &kp I     &kp O   &kp P     ,  &kp RTOP   ,
+    &kp LHOME   ,  &H4 A &H3 S &H2 D &H1 F &kp G  ,  &kp H  &H1 J  &H2 K     &H3 L   &H4 SEMI  ,  &dead_key  ,
+    &kp LSHIFT  ,  &kp Z &kp X &kp C &kp V &kp B  ,  &kp N  &kp M  &kp COMMA &kp DOT &kp FSLH  ,  &kp RSHIFT ,
         LTHUMB_TUCK , LTHUMB_HOME , LTHUMB_REACH  ,  RTHUMB_REACH , RTHUMB_HOME , RTHUMB_TUCK
   )>;
 };

--- a/include/aekeynox/extra_layers/bepo.dtsi
+++ b/include/aekeynox/extra_layers/bepo.dtsi
@@ -6,12 +6,12 @@
 // Same as the default base layer, but [N] becomes 1DK.
 &base_layer {
   display-name = "Base";
-  bindings = <
-    &kp TAB    &kp Q  &kp SQT &kp E  &kp R  &kp RBKT  &kp LBKT  &kp U  &kp I     &kp O   &kp P      &kp BACKSPACE
-    &kp ESCAPE &H4 A  &H3 S   &H2 D  &H1 F  &kp G     &kp H     &H1 J  &H2 K     &H3 L   &H4 SEMI   &kp ENTER
-    &kp LSHIFT &dash  &kp X   &kp C  &kp V  &kp B     &dead_key &kp M  &kp COMMA &kp DOT &kp FSLH   &kp RSHIFT
-           LTHUMB_TUCK  LTHUMB_HOME  LTHUMB_REACH     RTHUMB_REACH  RTHUMB_HOME  RTHUMB_TUCK
-  >;
+  bindings = <SELENIUM_KEYMAP_BINDINGS(
+    &kp LTOP   , &kp Q  &kp SQT &kp E  &kp R  &kp RBKT  ,   &kp LBKT  &kp U  &kp I     &kp O   &kp P     ,  &kp RTOP   ,
+    &kp LHOME  , &H4 A  &H3 S   &H2 D  &H1 F  &kp G     ,   &kp H     &H1 J  &H2 K     &H3 L   &H4 SEMI  ,  &kp RHOME  ,
+    &kp LSHIFT , &dash  &kp X   &kp C  &kp V  &kp B     ,   &dead_key &kp M  &kp COMMA &kp DOT &kp FSLH  ,  &kp RSHIFT ,
+              LTHUMB_TUCK , LTHUMB_HOME , LTHUMB_REACH  ,   RTHUMB_REACH , RTHUMB_HOME , RTHUMB_TUCK
+  )>;
 };
 
 / {
@@ -44,22 +44,22 @@
 
     one_dead_key {
       display-name = "1dk";
-      bindings = <
-        &trans   &kpc A     &kpc S    &kpc D  &kpc R    &kp RA(R)    &trans     &trans        &trans  &trans  &trans   &trans
-        &trans   &kp Z      &kp RA(S) &kp W   &kp T     &kp NUBS     &kp BSLH   &trans        &trans  &kpc O  &trans   &trans
-        &trans   &kp RA(N1) &kpc X    S_UNDER &kp RA(V) &kp RA(A)    &kp RA(D)  &kp RA(GRAVE) &trans  &trans  &trans   &trans
-                           &EZ_SL(ODK_SHIFT_LAYER)  &kp N  &trans    &trans  &trans  &trans
-      >;
+      bindings = <SELENIUM_KEYMAP_BINDINGS(
+        &trans , &kpc A     &kpc S    &kpc D  &kpc R    &kp RA(R)  ,   &trans     &trans        &trans  &trans  &trans , &trans
+        &trans , &kp Z      &kp RA(S) &kp W   &kp T     &kp NUBS   ,   &kp BSLH   &trans        &trans  &kpc O  &trans , &trans
+        &trans , &kp RA(N1) &kpc X    S_UNDER &kp RA(V) &kp RA(A)  ,   &kp RA(D)  &kp RA(GRAVE) &trans  &trans  &trans , &trans
+                      &EZ_SL(ODK_SHIFT_LAYER) , &kp N , &trans     ,   &trans , &trans , &trans
+      )>;
     };
 
     shifted_one_dead_key {
       display-name = "1dkShift";
-      bindings = <
-        &trans   &skpc A   &skpc S   &skpc D   &skpc R   &kp SA(R)    &trans   &trans  &trans  &trans  &trans   &trans
-        &trans   &kp RS(Z) &kp SA(S) &kp RS(W) &kp RS(T) &kp PIPE2    &kp PIPE &trans  &trans  &skpc O &trans   &trans
-        &trans   &trans    &skpc X   &trans    &kp N5    &kp SA(A)    &trans   &trans  &trans  &trans  &trans   &trans
-                                     &trans    &trans    &trans       &trans   &trans  &trans
-      >;
+      bindings = <SELENIUM_KEYMAP_BINDINGS(
+        &trans , &skpc A   &skpc S   &skpc D   &skpc R   &kp SA(R)  ,   &trans   &trans  &trans  &trans  &trans , &trans
+        &trans , &kp RS(Z) &kp SA(S) &kp RS(W) &kp RS(T) &kp PIPE2  ,   &kp PIPE &trans  &trans  &skpc O &trans , &trans
+        &trans , &trans    &skpc X   &trans    &kp N5    &kp SA(A)  ,   &trans   &trans  &trans  &trans  &trans , &trans
+                                       &trans , &trans , &trans     ,   &trans , &trans , &trans
+      )>;
     };
 
   };

--- a/include/aekeynox/outer_keys.h
+++ b/include/aekeynox/outer_keys.h
@@ -1,0 +1,23 @@
+// By default, use non-alpha keys on outer columns
+#ifndef USE_ALPHA_ON_6TH_COLUMNS
+  #define LTOP  TAB
+  #define LHOME ESCAPE
+  #define RTOP  BACKSPACE
+  #define RHOME ENTER
+
+// QWERTY-intl users might want to customize this section to better match their main language.
+// Here's an example that should work well with Latin/Romance languages.
+#elifdef KB_LAYOUT_QWERTY_INTL
+  #define LTOP  LS(N6) // dead circumflex
+  #define LHOME DQT    // dead diaeresis
+  #define RTOP  GRAVE  // dead grave accent
+  #define RHOME SQT    // dead accute accent
+
+// Other QWERTY and QWERTZ variants probably want the following:
+// keep the 6th column on the right, move the 7th column to the left.
+#else
+  #define LTOP  RBKT
+  #define LHOME BSLH
+  #define RTOP  LBKT
+  #define RHOME SQT
+#endif

--- a/include/aekeynox/outer_keys.h
+++ b/include/aekeynox/outer_keys.h
@@ -1,5 +1,5 @@
 // By default, use non-alpha keys on outer columns
-#ifndef USE_ALPHA_ON_6TH_COLUMNS
+#ifndef USE_ALPHA_ON_OUTER_KEYS
   #define LTOP  TAB
   #define LHOME ESCAPE
   #define RTOP  BACKSPACE

--- a/include/aekeynox/selenium.keymap
+++ b/include/aekeynox/selenium.keymap
@@ -40,7 +40,7 @@
       display-name = "Base";
       bindings = <SELENIUM_KEYMAP_BINDINGS(
         &kp LTOP   ,  &kp Q  &kp W  &kp E  &kp R  &kp T   ,   &kp Y  &kp U  &kp I     &kp O   &kp P     ,  &kp RTOP   ,
-        &kp LHOME  ,  &H4 A  &H3 S  &H2 D  &H1 F  &kp G   ,   &kp H  &H1 J  &H2 K     &H3 L   &H4 SEMI  ,  &kp RHOME  ,
+        &kp LHOME  ,  &H4 A  &H3 S  &H2 D  &H1 F  &kp G   ,   &kp H  &H1 J  &H2 K     &H3 L   &H4 SEMI  ,  &kp RHOME  ,
         &kp LSHIFT ,  &kp Z  &kp X  &kp C  &kp V  &kp B   ,   &kp N  &kp M  &kp COMMA &kp DOT &kp FSLH  ,  &kp RSHIFT ,
                LTHUMB_TUCK , LTHUMB_HOME , LTHUMB_REACH   ,   RTHUMB_REACH , RTHUMB_HOME , RTHUMB_TUCK
       )>;

--- a/include/aekeynox/selenium.keymap
+++ b/include/aekeynox/selenium.keymap
@@ -12,6 +12,8 @@
 #include "bindings.h"     // default SELENIUM_KEYMAP_BINDINGS macro
 #include "mappings.dtsi"  // key mapping helpers and macros
 #include "hold_taps.dtsi" // defines thumb keys and homerow mods
+#include "outer_keys.h"   // defines outer keys on the 6th columns
+
 
 /**
  * All keyboard layers are defined by blocks on a 42-key basis, as follows:
@@ -37,9 +39,9 @@
     base_layer: base_layer {
       display-name = "Base";
       bindings = <SELENIUM_KEYMAP_BINDINGS(
-        &kp TAB    ,  &kp Q  &kp W  &kp E  &kp R  &kp T   ,   &kp Y  &kp U  &kp I     &kp O   &kp P     ,  &kp BACKSPACE ,
-        &kp ESCAPE ,  &H4 A  &H3 S  &H2 D  &H1 F  &kp G   ,   &kp H  &H1 J  &H2 K     &H3 L   &H4 SEMI  ,  &kp ENTER     ,
-        &kp LSHIFT ,  &kp Z  &kp X  &kp C  &kp V  &kp B   ,   &kp N  &kp M  &kp COMMA &kp DOT &kp FSLH  ,  &kp RSHIFT    ,
+        &kp LTOP   ,  &kp Q  &kp W  &kp E  &kp R  &kp T   ,   &kp Y  &kp U  &kp I     &kp O   &kp P     ,  &kp RTOP   ,
+        &kp LHOME  ,  &H4 A  &H3 S  &H2 D  &H1 F  &kp G   ,   &kp H  &H1 J  &H2 K     &H3 L   &H4 SEMI  ,  &kp RHOME  ,
+        &kp LSHIFT ,  &kp Z  &kp X  &kp C  &kp V  &kp B   ,   &kp N  &kp M  &kp COMMA &kp DOT &kp FSLH  ,  &kp RSHIFT ,
                LTHUMB_TUCK , LTHUMB_HOME , LTHUMB_REACH   ,   RTHUMB_REACH , RTHUMB_HOME , RTHUMB_TUCK
       )>;
     };

--- a/include/aekeynox/settings.h
+++ b/include/aekeynox/settings.h
@@ -25,6 +25,12 @@
 // #define MACOS
 // #define LINUX
 
+// By default, Ækeynox uses non-alphanumeric keys on the 6th columns:
+// Tab, Escape, Backspace, Enter.
+// Uncomment the following line to use these columns for alpha keys instead.
+
+// #define USE_ALPHA_ON_6TH_COLUMNS
+
 
 /******************************************************************************
  * Layout Emulation

--- a/include/aekeynox/settings.h
+++ b/include/aekeynox/settings.h
@@ -29,7 +29,7 @@
 // Tab, Escape, Backspace, Enter.
 // Uncomment the following line to use these columns for alpha keys instead.
 
-// #define USE_ALPHA_ON_6TH_COLUMNS
+// #define USE_ALPHA_ON_OUTER_KEYS
 
 
 /******************************************************************************


### PR DESCRIPTION
As a user, I want to:

- use proper dead keys with QWERTY-intl, which requires the 6th columns on both sides;
- use the 6th column for some layouts where it can make sense, e.g. QWERTZ-ch.

The <kbd>1dk</kbd> option is what we want to propose by default, and that’s a hill I’ll fight on; but having a setting for users who don’t want to deal with <kbd>1dk</kbd> is worth experimenting, imho.

I’m not so sure about the two names I’ve chosen (`USE_ALPHA_ON_6TH_COLUMNS`, `outer_keys.h`), suggestions are welcome.