### PR TITLE
refacto: experiment an OSKEY-like approach

### DIFF
--- a/include/aekeynox/aliases/azerty.h
+++ b/include/aekeynox/aliases/azerty.h
@@ -2,68 +2,6 @@
 #include <zephyr/sys/util_macro.h>
 
 /**
- * Action Combos
- */
-
-#define X_UNDO  &kp CMD(W)
-#define X_CUT   &kp CMD(X)
-#define X_COPY  &kp CMD(C)
-#define X_PASTE &kp CMD(V)
-#define X_REDO  &kp CMD(Y)
-
-#define X_CTL_W &kp LC(Z)
-#define X_SAVE  &kp CMD(S)
-#define X_ALL   &kp CMD(Q)
-
-/**
- * Arsenik Symbols:
- *   ^<>$% @&*'`
- *   {()}= \+-/"
- *   ~[]_# |!;:?
- */
-
-// first row
-// XXX; S_CARET is OS-specific
-// XXX; S_LT    is OS-specific
-// XXX; S_GT    is OS-specific
-#define S_DLLR  &kp RBKT
-#define S_PRCNT &kp LS(SQT)
-// XXX; S_AT    is OS-specific
-#define S_AMPS  &kp N1
-// XXX; S_STAR  is OS-specific
-#define S_SQT   &kp N4
-// XXX; S_GRAVE &digraph RA(N7) SPACE
-
-// second row
-// XXX; S_LBRC  is OS-specific
-#define S_LPAR  &kp N5
-#define S_RPAR  &kp MINUS
-// XXX; S_RBRC  is OS-specific
-#define S_EQUAL &kp EQUAL
-// XXX; S_BSLH  is OS-specific
-// XXX; S_PLUS  is OS-specific
-// XXX; S_MINUS is OS-specific
-#define S_FSLH  &kp LS(DOT)
-#define S_DQT   &kp N3
-
-// third row
-// XXX; S_TILDE is OS-specific
-// XXX; S_LBKT  is OS-specific
-// XXX; S_RBKT  is OS-specific
-// XXX; S_UNDER is OS-specific
-// XXX; S_HASH  is OS-specific
-// XXX; S_PIPE  is OS-specific
-// XXX; S_EXCL  is OS-specific
-#define S_SEMI  &kp COMMA
-#define S_COLON &kp DOT
-#define S_QMARK &kp LS(M)
-
-// extra
-#define S_COMMA &kp M
-#define S_DOT   &kp LS(COMMA)
-// XXX; S_MONEY is OS-specific
-
-/**
  * OS_SELECT
  */
 
@@ -80,47 +18,82 @@
   #define OS_SELECT(behavior, i2, i3, i4) behavior
 #endif
 
-#define DEAD_CIRCUMFLEX LBKT
-#define DEAD_DIAERESIS  LBRC
-#define DEAD_GRAVE OS_DEFINE(RA(N9),       ,       , NUHS )
-#define DEAD_TILDE OS_DEFINE(RA(N2),       ,       , RA(N))
+/**
+ * Action Combos
+ */
 
-#define DK_CIR &kp DEAD_CIRCUMFLEX
-#define DK_DIA &kp DEAD_DIAERESIS
-#define DK_GRV &kp DEAD_GRAVE
-#define DK_TLD &kp DEAD_TILDE
+#define X_UNDO  &kp CMD(W)
+#define X_CUT   &kp CMD(X)
+#define X_COPY  &kp CMD(C)
+#define X_PASTE &kp CMD(V)
+#define X_REDO  &kp CMD(Y)
 
-#define DI_CIR &digraph DEAD_CIRCUMFLEX
-#define DI_DIA &digraph DEAD_DIAERESIS
-#define DI_GRV &digraph DEAD_GRAVE
-#define DI_TLD &digraph DEAD_TILDE
+#define X_CTL_W &kp LC(Z)
+#define X_SAVE  &kp CMD(S)
+#define X_ALL   &kp CMD(Q)
+
+/**
+ * Dead Keys
+ */
+
+#define DK_CIR            &kp      LBKT                               // dead circumflex
+#define DI_CIR            &digraph LBKT
+#define DK_DIA            &kp      LBRC                               // dead diaeresis
+#define DI_DIA            &digraph LBRC
+#define DK_GRV OS_SELECT( &kp      RA(N9) ,, &kp      NUHS  , &none ) // dead grave (n/a on Linux)
+#define DI_GRV OS_SELECT( &digraph RA(N9) ,, &digraph NUHS  , &kp   )
+#define DK_TLD OS_SELECT( &kp      RA(N2) ,, &kp      RA(N) , &none ) // dead tilde (n/a on Linux)
+#define DI_TLD OS_SELECT( &digraph RA(N2) ,, &digraph RA(N) , &kp   )
+
+/**
+ * Arsenik Symbols:
+ *   ^<>$% @&*'`
+ *   {()}= \+-/"
+ *   ~[]_# |!;:?
+ */
 
 #define SA(key) RS(RA(key))
 
-//      symbol             default         CP1252          macOS           Linux
-#define S_CARET OS_SELECT( &kp RA(N9)    ,               , DI_CIR SPACE  ,               )
-#define S_LT    OS_SELECT( &kp NUBS      ,               , &kp GRAVE     ,               )
-#define S_GT    OS_SELECT( &kp PIPE2     ,               , &kp TILDE     ,               )
-#define S_AT    OS_SELECT( &kp RA(N0)    ,               , &kp NUBS      ,               )
-#define S_STAR  OS_SELECT( &kp BSLH      ,               , &kp RBRC      ,               )
-#define S_GRAVE OS_SELECT( DI_GRV SPACE  ,               ,               , &kp RA(N7)    )
+// first row             ( default       ,, macOS         , Linux         )
+#define S_CARET OS_SELECT( &kp RA(N9)    ,, DI_CIR SPACE  ,               )
+#define S_LT    OS_SELECT( &kp NUBS      ,, &kp GRAVE     ,               )
+#define S_GT    OS_SELECT( &kp PIPE2     ,, &kp TILDE     ,               )
+#define S_DLLR             &kp RBKT
+#define S_PRCNT            &kp LS(SQT)
+#define S_AT    OS_SELECT( &kp RA(N0)    ,, &kp NUBS      ,               )
+#define S_AMPS             &kp N1
+#define S_STAR  OS_SELECT( &kp BSLH      ,, &kp RBRC      ,               )
+#define S_SQT              &kp N4
+#define S_GRAVE OS_SELECT( DI_GRV SPACE  ,,               , &kp RA(N7)    )
 
-#define S_LBRC  OS_SELECT( &kp RA(N4)    ,               , &kp RA(N5)    ,               )
-#define S_RBRC  OS_SELECT( &kp RA(EQUAL) ,               , &kp RA(MINUS) ,               )
-#define S_BSLH  OS_SELECT( &kp RA(N8)    ,               , &kp SA(DOT)   ,               )
-#define S_PLUS  OS_SELECT( &kp PLUS      ,               , &kp QMARK     ,               )
-#define S_MINUS OS_SELECT( &kp N6        ,               , &kp EQUAL     ,               )
+// second row            ( default       ,, macOS         , Linux         )
+#define S_LBRC  OS_SELECT( &kp RA(N4)    ,, &kp RA(N5)    ,               )
+#define S_LPAR             &kp N5
+#define S_RPAR             &kp MINUS
+#define S_RBRC  OS_SELECT( &kp RA(EQUAL) ,, &kp RA(MINUS) ,               )
+#define S_EQUAL            &kp EQUAL
+#define S_BSLH  OS_SELECT( &kp RA(N8)    ,, &kp SA(DOT)   ,               )
+#define S_PLUS  OS_SELECT( &kp PLUS      ,, &kp QMARK     ,               )
+#define S_MINUS OS_SELECT( &kp N6        ,, &kp EQUAL     ,               )
+#define S_FSLH             &kp LS(DOT)
+#define S_DQT              &kp N3
 
-#define S_TILDE OS_SELECT( DI_TLD SPACE  ,               ,               , &kp RA(N2)    )
-#define S_LBKT  OS_SELECT( &kp RA(N5)    ,               , &kp SA(N5)    ,               )
-#define S_RBKT  OS_SELECT( &kp RA(EQUAL) ,               , &kp SA(MINUS) ,               )
-#define S_UNDER OS_SELECT( &kp N8        ,               , &kp PLUS      ,               )
-#define S_HASH  OS_SELECT( &kp RA(N3)    ,               , &kp PIPE2     ,               )
-#define S_PIPE  OS_SELECT( &kp RA(N6)    ,               , &kp SA(L)     ,               )
-#define S_EXCL  OS_SELECT( &kp FSLH      ,               , &kp N8        ,               )
+// third row             ( default       ,, macOS         , Linux         )
+#define S_TILDE OS_SELECT( DI_TLD SPACE  ,,               , &kp RA(N2)    )
+#define S_LBKT  OS_SELECT( &kp RA(N5)    ,, &kp SA(N5)    ,               )
+#define S_RBKT  OS_SELECT( &kp RA(EQUAL) ,, &kp SA(MINUS) ,               )
+#define S_UNDER OS_SELECT( &kp N8        ,, &kp PLUS      ,               )
+#define S_HASH  OS_SELECT( &kp RA(N3)    ,, &kp PIPE2     ,               )
+#define S_PIPE  OS_SELECT( &kp RA(N6)    ,, &kp SA(L)     ,               )
+#define S_EXCL  OS_SELECT( &kp FSLH      ,, &kp N8        ,               )
+#define S_SEMI             &kp COMMA
+#define S_COLON            &kp DOT
+#define S_QMARK            &kp LS(M)
 
-#define S_MONEY OS_SELECT( &kp RA(E)     ,               , &kp RA(RBKT)  ,               )
-
+// extra                 ( default       ,, macOS         , Linux         )
+#define S_COMMA            &kp M
+#define S_DOT              &kp LS(COMMA)
+#define S_MONEY OS_SELECT( &kp RA(E)     ,, &kp RA(RBKT)  ,               )
 
 /**
  * Non-ASCII Symbols
@@ -134,181 +107,73 @@
 #define C_UGRV &kp SQT // ù
 #define C_CCDL &kp N9  // ç
 
-// uppercase: É À È Ù Ç
-#if defined LINUX || defined MACOS
-  #define SC_EACU &caps N2
-  #define SC_AGRV &caps N0
-  #define SC_EGRV &caps N7
-  #define SC_UGRV &caps SQT
-  #define SC_CCDL &caps N9
-#elif defined ENABLE_CP1252_ALT_CODES
-  #define SC_EACU CP1252_UPPERCASE_E_ACUTE
-  #define SC_AGRV CP1252_UPPERCASE_A_GRAVE
-  #define SC_EGRV CP1252_UPPERCASE_E_GRAVE
-  #define SC_UGRV CP1252_UPPERCASE_U_GRAVE
-  #define SC_CCDL CP1252_UPPERCASE_C_CEDILLA
-#else
-  #define SC_EACU &kp LS(E)
-  #define SC_AGRV &kp LS(Q)
-  #define SC_EGRV &kp LS(E)
-  #define SC_UGRV &kp LS(U)
-  #define SC_CCDL &kp LS(C)
-#endif
+// uppercase: É À È Ù Ç   ( default   , CP1252                     , macOS     , Linux     )
+#define SC_EACU OS_SELECT ( &kp LS(E) , CP1252_UPPERCASE_E_ACUTE   , &caps N2  , &caps N2  ) // É
+#define SC_AGRV OS_SELECT ( &kp LS(A) , CP1252_UPPERCASE_A_GRAVE   , &caps N0  , &caps N0  ) // À
+#define SC_EGRV OS_SELECT ( &kp LS(E) , CP1252_UPPERCASE_E_GRAVE   , &caps N7  , &caps N7  ) // È
+#define SC_UGRV OS_SELECT ( &kp LS(U) , CP1252_UPPERCASE_U_GRAVE   , &caps SQT , &caps SQT ) // Ù
+#define SC_CCDL OS_SELECT ( &kp LS(C) , CP1252_UPPERCASE_C_CEDILLA , &caps N9  , &caps N9  ) // Ç
 
-// circumflex accent
-#define  C_ACRC DI_CIR Q     // â
+// circumflex
+#define  C_ACRC DI_CIR    Q  // â
 #define SC_ACRC DI_CIR RS(Q) // Â
-#define  C_ECRC DI_CIR E     // ê
+#define  C_ECRC DI_CIR    E  // ê
 #define SC_ECRC DI_CIR RS(E) // Ê
-#define  C_ICRC DI_CIR I     // î
+#define  C_ICRC DI_CIR    I  // î
 #define SC_ICRC DI_CIR RS(I) // Î
-#define  C_OCRC DI_CIR O     // ô
+#define  C_OCRC DI_CIR    O  // ô
 #define SC_OCRC DI_CIR RS(O) // Ô
-#define  C_UCRC DI_CIR U     // û
+#define  C_UCRC DI_CIR    U  // û
 #define SC_UCRC DI_CIR RS(U) // Û
-#define  C_YCRC DI_CIR Y     // ŷ
+#define  C_YCRC DI_CIR    Y  // ŷ
 #define SC_YCRC DI_CIR RS(Y) // Ŷ
 
 // diaeresis
-#define  C_ADIA DI_DIA A     // ä
+#define  C_ADIA DI_DIA    A  // ä
 #define SC_ADIA DI_DIA RS(A) // Ä
-#define  C_EDIA DI_DIA E     // ë
+#define  C_EDIA DI_DIA    E  // ë
 #define SC_EDIA DI_DIA RS(E) // Ë
-#define  C_IDIA DI_DIA I     // ï
+#define  C_IDIA DI_DIA    I  // ï
 #define SC_IDIA DI_DIA RS(I) // Ï
-#define  C_ODIA DI_DIA O     // ö
+#define  C_ODIA DI_DIA    O  // ö
 #define SC_ODIA DI_DIA RS(O) // Ö
-#define  C_UDIA DI_DIA U     // ü
+#define  C_UDIA DI_DIA    U  // ü
 #define SC_UDIA DI_DIA RS(U) // Ü
-#define  C_YDIA DI_DIA Y     // ÿ
+#define  C_YDIA DI_DIA    Y  // ÿ
 #define SC_YDIA DI_DIA RS(Y) // Ÿ
 
-// other special letters: œ, æ, ß, ñ
-#ifdef LINUX
-  #define  C_OE &digraph O E
-  #define SC_OE &digraph LS(O) LS(E)
-  #define  C_AE &kp RA(Q) // æ
-  #define SC_AE &kp SA(Q) // æ
-  #define  C_SZ &kp RA(S) // ß
-#elifdef MACOS
-  #define  C_OE &kp RA(O) // œ
-  #define SC_OE &kp SA(O) // œ
-  #define  C_AE &kp RA(Q) // æ
-  #define SC_AE &kp SA(Q) // Æ
-  #define  C_SZ &kp RA(B) // ß
-#elifdef ENABLE_CP1252_ALT_CODES
-  #define  C_OE CP1252_LOWERCASE_OE // œ
-  #define SC_OE CP1252_UPPERCASE_OE // Œ
-  #define  C_AE CP1252_LOWERCASE_AE // æ
-  #define SC_AE CP1252_UPPERCASE_AE // Æ
-  #define  C_SZ CP1252_LOWERCASE_SZ // ß
-#else // Windows without alt-codes
-  #define  C_OE &digraph O E
-  #define SC_OE &digraph LS(O) LS(E)
-  #define  C_AE &digraph Q E
-  #define SC_AE &digraph LS(Q) LS(E)
-  #define  C_SZ &digraph S S
-#endif
-#ifdef LINUX
-  #define  C_NTLD &kp N     // XXX
-  #define SC_NTLD &kp LS(N) // XXX
-#elifdef MACOS
-  #define  C_NTLD &digraph RA(N) N     // ñ
-  #define SC_NTLD &digraph RA(N) LS(N) // Ñ
-#else
-  #define  C_NTLD &digraph RA(N2) N     // ñ
-  #define SC_NTLD &digraph RA(N2) LS(N) // ñ
-#endif
+// tilde
+#define  C_NTLD DI_TLD    N  // ñ
+#define SC_NTLD DI_TLD LS(N) // Ñ
 
-// quote signs
-#ifdef LINUX
-  #define C_LODQT &kp RA(V) // „
-  #define C_LDQT  &kp RA(B) // “
-  #define C_RDQT  &kp RA(N) // ”
-  #define C_LGQT  &kp RA(W) // «
-  #define C_RGQT  &kp RA(X) // »
-  #define C_APOS  &kp SA(N) // ’
-#elifdef ENABLE_CP1252_ALT_CODES
-  #define C_LODQT CP1252_LOW_DOUBLE_QUOTE   // „
-  #define C_LDQT  CP1252_LEFT_DOUBLE_QUOTE  // “
-  #define C_RDQT  CP1252_RIGHT_DOUBLE_QUOTE // ”
-  #define C_LGQT  CP1252_LEFT_GUILLEMET     // «
-  #define C_RGQT  CP1252_RIGHT_GUILLEMET    // »
-  #define C_APOS  CP1252_RIGHT_SINGLE_QUOTE // ’
-#elifdef MACOS
-  #define C_LODQT &none
-  #define C_LDQT  &none
-  #define C_RDQT  &none
-  #define C_LGQT  &kp RA(N7) // « = ⌥7
-  #define C_RGQT  &kp SA(N7) // » = ⌥⇧7
-  #define C_APOS  &kp N4     // '
-#else // Windows without alt-codes
-  #define C_LODQT &none
-  #define C_LDQT  &none
-  #define C_RDQT  &none
-  #define C_LGQT  &kp N3 // "
-  #define C_RGQT  &kp N3 // "
-  #define C_APOS  &kp N4 // '
-#endif
+// œ, æ, ß              ( default              , CP1252              , macOS     , Linux     )
+#define  C_OE OS_SELECT ( &digraph    O     E  , CP1252_LOWERCASE_OE , &kp RA(O) ,           ) // œ
+#define SC_OE OS_SELECT ( &digraph LS(O) LS(E) , CP1252_UPPERCASE_OE , &kp SA(O) ,           ) // œ
+#define  C_AE OS_SELECT ( &digraph    Q     E  , CP1252_LOWERCASE_AE , &kp RA(Q) , &kp RA(Q) ) // æ
+#define SC_AE OS_SELECT ( &digraph LS(Q) LS(E) , CP1252_UPPERCASE_AE , &kp SA(Q) , &kp SA(Q) ) // Æ
+#define  C_SZ OS_SELECT ( &digraph    S     S  , CP1252_LOWERCASE_SZ , &kp RA(B) , &kp RA(S) ) // ß
 
-// punctuation (generic)
-#ifdef ENABLE_CP1252_ALT_CODES
-  #define C_NDASH CP1252_EN_DASH    // –
-  #define C_MDASH CP1252_EM_DASH    // —
-  #define C_ELLIP CP1252_ELLIPSIS   // …
-  #define C_BLLT  CP1252_BULLET     // •
-  #define C_MDOT  CP1252_MIDDLE_DOT // ·
-  #define C_NBSP  CP1252_NO_BREAK_SPACE
-#elifdef MACOS
-  #define C_MDASH &kp SA(EQUAL) // —
-  #define C_NDASH &kp RA(EQUAL) // –
-  #define C_ELLIP &kp RA(COMMA) // … (⌥;)
-  #define C_BLLT  &kp SA(COMMA) // •
-  #define C_MDOT  S_DOT         // .
-  #define C_NBSP  &kp RA (SPACE)
-#else // unsupported
-  #define C_NDASH &digraph N6 N6 // --
-  #define C_MDASH &digraph N6 N6 // --
-  #define C_ELLIP &ellipsis      // ...
-  #define C_BLLT  S_MINUS        // -
-  #define C_MDOT  S_DOT          // .
-  #define C_NBSP  &kp SPACE
-#endif
+// punctuation            ( default        , CP1252                    , macOS         , Linux         )
+#define C_LODQT OS_SELECT ( &none          , CP1252_LOW_DOUBLE_QUOTE   ,               ,               ) // „
+#define C_LDQT  OS_SELECT ( &none          , CP1252_LEFT_DOUBLE_QUOTE  ,               ,               ) // “
+#define C_RDQT  OS_SELECT ( &none          , CP1252_RIGHT_DOUBLE_QUOTE ,               ,               ) // ”
+#define C_LGQT  OS_SELECT ( &kp N3         , CP1252_LEFT_GUILLEMET     , &kp RA(N7)    ,               ) // «
+#define C_RGQT  OS_SELECT ( &kp N3         , CP1252_RIGHT_GUILLEMET    , &kp SA(N7)    ,               ) // »
+#define C_APOS  OS_SELECT ( &kp N4         , CP1252_RIGHT_SINGLE_QUOTE , &kp N4        ,               ) // ’
+#define C_NDASH OS_SELECT ( &digraph N6 N6 , CP1252_EN_DASH            , &kp SA(EQUAL) ,               ) // –
+#define C_MDASH OS_SELECT ( &digraph N6 N6 , CP1252_EM_DASH            , &kp RA(EQUAL) ,               ) // —
+#define C_ELLIP OS_SELECT ( &ellipsis      , CP1252_ELLIPSIS           , &kp RA(COMMA) ,               ) // …
+#define C_BLLT  OS_SELECT ( S_MINUS        , CP1252_BULLET             , &kp SA(COMMA) ,               ) // •
+#define C_MDOT  OS_SELECT ( S_DOT          , CP1252_MIDDLE_DOT         ,               ,               ) // ·
+#define C_LCXE  OS_SELECT ( &none          , CP1252_INVERTED_XMARK     , &kp RA(N8)    , &kp SA(N1)    ) // ¡
+#define C_KRAMQ OS_SELECT ( &none          , CP1252_INVERTED_QMARK     , &kp SA(M)     , &kp SA(MINUS) ) // ¿
+#define C_FEM   OS_SELECT ( &none          , CP1252_FEMININE_ORDINAL   ,               ,               ) // ª
+#define C_MASC  OS_SELECT ( &none          , CP1252_MASCULINE_ORDINAL  ,               ,               ) // º
+#define C_NBSP  OS_SELECT ( &kp SPACE      , CP1252_NO_BREAK_SPACE     , &kp RA(SPACE) ,               )
 
-// punctuation (Spanish)
-#ifdef LINUX
-  #define C_LCXE  &kp SA(N1)
-  #define C_KRAMQ &kp SA(MINUS)
-  #define C_FEM   &none
-  #define C_MASC  &none
-#elifdef ENABLE_CP1252_ALT_CODES
-  #define C_LCXE  CP1252_INVERTED_XMARK     // ¡
-  #define C_KRAMQ CP1252_INVERTED_QMARK     // ¿
-  #define C_FEM   CP1252_FEMININE_ORDINAL   // ª
-  #define C_MASC  CP1252_MASCULINE_ORDINAL  // º
-#else // macOS or Windows without alt-codes
-  #define C_LCXE  &kp RA(8) // ¡
-  #define C_KRAMQ &kp SA(M) // ¿
-  #define C_FEM   &none
-  #define C_MASC  &none
-#endif
-
-// math
-#define C_DEG   &kp UNDER // °
-#ifdef MACOS
-  #define C_MICRO &kp RA(SEMI) // µ
-  #define C_EURO  &kp RA(RBKT) // €
-#else
-  #define C_MICRO &kp PIPE     // µ
-  #define C_EURO  &kp RA(E)    // €
-#endif
-#ifdef LINUX
-  #define C_CENT  &kp RA(C)     // ¢
-  #define C_MULT  &kp SA(COMMA) // ×
-#elifdef ENABLE_CP1252_ALT_CODES
-  #define C_CENT  CP1252_CENT           // ¢
-  #define C_MULT  CP1252_MULTIPLICATION // ×
-#else // macOS or Windows without alt-codes
-  #define C_CENT  &kp C
-  #define C_MULT  &kp X
-#endif
+// math                   ( default   , CP1252                , macOS         , Linux         )
+#define C_EURO  OS_SELECT ( &kp RA(E) ,                       , &kp RA(RBKT)  ,               ) // €
+#define C_CENT  OS_SELECT ( &kp C     , CP1252_CENT           ,               , &kp RA(C)     ) // ¢
+#define C_MULT  OS_SELECT ( &kp X     , CP1252_MULTIPLICATION ,               , &kp SA(COMMA) ) // ×
+#define C_MICRO OS_SELECT ( &kp PIPE  ,                       , &kp RA(SEMI)  ,               ) // µ
+#define C_DEG               &kp UNDER                                                           // °

--- a/include/aekeynox/aliases/azerty.h
+++ b/include/aekeynox/aliases/azerty.h
@@ -1,4 +1,5 @@
 #include <dt-bindings/zmk/keys.h>
+#include <zephyr/sys/util_macro.h>
 
 /**
  * Action Combos
@@ -66,20 +67,23 @@
  * OS_SELECT
  */
 
+#define OS_SELECT_OR_DEFAULT(behavior, default) \
+  COND_CODE_1(IS_EMPTY(behavior), (default), (behavior))
+
 #ifdef LINUX
-  #define OS_SELECT(i1, i2, i3, behavior) behavior
+  #define OS_SELECT(default, i2, i3, behavior) OS_SELECT_OR_DEFAULT(behavior, default)
 #elifdef MACOS
-  #define OS_SELECT(i1, i2, behavior, i4) behavior
+  #define OS_SELECT(default, i2, behavior, i4) OS_SELECT_OR_DEFAULT(behavior, default)
 #elifdef ENABLE_CP1252_ALT_CODES
-  #define OS_SELECT(i1, behavior, i3, i4) behavior
+  #define OS_SELECT(default, behavior, i3, i4) OS_SELECT_OR_DEFAULT(behavior, default)
 #else
   #define OS_SELECT(behavior, i2, i3, i4) behavior
 #endif
 
 #define DEAD_CIRCUMFLEX LBKT
 #define DEAD_DIAERESIS  LBRC
-#define DEAD_GRAVE OS_DEFINE(RA(N9), RA(N9), RA(N9), NUHS )
-#define DEAD_TILDE OS_DEFINE(RA(N2), RA(N2), RA(N2), RA(N))
+#define DEAD_GRAVE OS_DEFINE(RA(N9),       ,       , NUHS )
+#define DEAD_TILDE OS_DEFINE(RA(N2),       ,       , RA(N))
 
 #define DK_CIR &kp DEAD_CIRCUMFLEX
 #define DK_DIA &kp DEAD_DIAERESIS
@@ -94,28 +98,28 @@
 #define SA(key) RS(RA(key))
 
 //      symbol             default         CP1252          macOS           Linux
-#define S_CARET OS_SELECT( &kp RA(N9)    , &kp RA(N9)    , DI_CIR SPACE  , &kp RA(N9)    )
-#define S_LT    OS_SELECT( &kp NUBS      , &kp NUBS      , &kp GRAVE     , &kp NUBS      )
-#define S_GT    OS_SELECT( &kp PIPE2     , &kp PIPE2     , &kp TILDE     , &kp PIPE2     )
-#define S_AT    OS_SELECT( &kp RA(N0)    , &kp RA(N0)    , &kp NUBS      , &kp RA(N0)    )
-#define S_STAR  OS_SELECT( &kp BSLH      , &kp BSLH      , &kp RBRC      , &kp BSLH      )
-#define S_GRAVE OS_SELECT( DI_GRV SPACE  , DI_GRV SPACE  , DI_GRV SPACE  , &kp RA(N7)    )
+#define S_CARET OS_SELECT( &kp RA(N9)    ,               , DI_CIR SPACE  ,               )
+#define S_LT    OS_SELECT( &kp NUBS      ,               , &kp GRAVE     ,               )
+#define S_GT    OS_SELECT( &kp PIPE2     ,               , &kp TILDE     ,               )
+#define S_AT    OS_SELECT( &kp RA(N0)    ,               , &kp NUBS      ,               )
+#define S_STAR  OS_SELECT( &kp BSLH      ,               , &kp RBRC      ,               )
+#define S_GRAVE OS_SELECT( DI_GRV SPACE  ,               ,               , &kp RA(N7)    )
 
-#define S_LBRC  OS_SELECT( &kp RA(N4)    , &kp RA(N4)    , &kp RA(N5)    , &kp RA(N4)    )
-#define S_RBRC  OS_SELECT( &kp RA(EQUAL) , &kp RA(EQUAL) , &kp RA(MINUS) , &kp RA(EQUAL) )
-#define S_BSLH  OS_SELECT( &kp RA(N8)    , &kp RA(N8)    , &kp SA(DOT)   , &kp RA(N8)    )
-#define S_PLUS  OS_SELECT( &kp PLUS      , &kp PLUS      , &kp QMARK     , &kp PLUS      )
-#define S_MINUS OS_SELECT( &kp N6        , &kp N6        , &kp EQUAL     , &kp N6        )
+#define S_LBRC  OS_SELECT( &kp RA(N4)    ,               , &kp RA(N5)    ,               )
+#define S_RBRC  OS_SELECT( &kp RA(EQUAL) ,               , &kp RA(MINUS) ,               )
+#define S_BSLH  OS_SELECT( &kp RA(N8)    ,               , &kp SA(DOT)   ,               )
+#define S_PLUS  OS_SELECT( &kp PLUS      ,               , &kp QMARK     ,               )
+#define S_MINUS OS_SELECT( &kp N6        ,               , &kp EQUAL     ,               )
 
-#define S_TILDE OS_SELECT( DI_TLD SPACE  , DI_TLD SPACE  , DI_TLD SPACE  , &kp RA(N2)    )
-#define S_LBKT  OS_SELECT( &kp RA(N5)    , &kp RA(N5)    , &kp SA(N5)    , &kp RA(N5)    )
-#define S_RBKT  OS_SELECT( &kp RA(EQUAL) , &kp RA(EQUAL) , &kp SA(MINUS) , &kp RA(EQUAL) )
-#define S_UNDER OS_SELECT( &kp N8        , &kp N8        , &kp PLUS      , &kp N8        )
-#define S_HASH  OS_SELECT( &kp RA(N3)    , &kp RA(N3)    , &kp PIPE2     , &kp RA(N3)    )
-#define S_PIPE  OS_SELECT( &kp RA(N6)    , &kp RA(N6)    , &kp SA(L)     , &kp RA(N6)    )
-#define S_EXCL  OS_SELECT( &kp FSLH      , &kp FSLH      , &kp N8        , &kp FSLH      )
+#define S_TILDE OS_SELECT( DI_TLD SPACE  ,               ,               , &kp RA(N2)    )
+#define S_LBKT  OS_SELECT( &kp RA(N5)    ,               , &kp SA(N5)    ,               )
+#define S_RBKT  OS_SELECT( &kp RA(EQUAL) ,               , &kp SA(MINUS) ,               )
+#define S_UNDER OS_SELECT( &kp N8        ,               , &kp PLUS      ,               )
+#define S_HASH  OS_SELECT( &kp RA(N3)    ,               , &kp PIPE2     ,               )
+#define S_PIPE  OS_SELECT( &kp RA(N6)    ,               , &kp SA(L)     ,               )
+#define S_EXCL  OS_SELECT( &kp FSLH      ,               , &kp N8        ,               )
 
-#define S_MONEY OS_SELECT( &kp RA(E)     , &kp RA(E)     , &kp RA(RBKT)  , &kp RA(E)     )
+#define S_MONEY OS_SELECT( &kp RA(E)     ,               , &kp RA(RBKT)  ,               )
 
 
 /**

--- a/include/aekeynox/aliases/azerty.h
+++ b/include/aekeynox/aliases/azerty.h
@@ -22,37 +22,37 @@
  */
 
 // first row
-#define S_CARET &kp RA(N9)
-#define S_LT    &kp NUBS
-#define S_GT    &kp PIPE2
+// XXX; S_CARET is OS-specific
+// XXX; S_LT    is OS-specific
+// XXX; S_GT    is OS-specific
 #define S_DLLR  &kp RBKT
 #define S_PRCNT &kp LS(SQT)
-#define S_AT    &kp RA(N0)
+// XXX; S_AT    is OS-specific
 #define S_AMPS  &kp N1
-#define S_STAR  &kp BSLH
+// XXX; S_STAR  is OS-specific
 #define S_SQT   &kp N4
-#define S_GRAVE &digraph RA(N7) SPACE
+// XXX; S_GRAVE &digraph RA(N7) SPACE
 
 // second row
-#define S_LBRC  &kp RA(N4)
+// XXX; S_LBRC  is OS-specific
 #define S_LPAR  &kp N5
 #define S_RPAR  &kp MINUS
-#define S_RBRC  &kp RA(EQUAL)
+// XXX; S_RBRC  is OS-specific
 #define S_EQUAL &kp EQUAL
-#define S_BSLH  &kp RA(N8)
-#define S_PLUS  &kp PLUS
-#define S_MINUS &kp N6
+// XXX; S_BSLH  is OS-specific
+// XXX; S_PLUS  is OS-specific
+// XXX; S_MINUS is OS-specific
 #define S_FSLH  &kp LS(DOT)
 #define S_DQT   &kp N3
 
 // third row
-#define S_TILDE &digraph RA(N2) SPACE
-#define S_LBKT  &kp RA(N5)
-#define S_RBKT  &kp RA(MINUS)
-#define S_UNDER &kp N8
-#define S_HASH  &kp RA(N3)
-#define S_PIPE  &kp RA(N6)
-#define S_EXCL  &kp FSLH
+// XXX; S_TILDE is OS-specific
+// XXX; S_LBKT  is OS-specific
+// XXX; S_RBKT  is OS-specific
+// XXX; S_UNDER is OS-specific
+// XXX; S_HASH  is OS-specific
+// XXX; S_PIPE  is OS-specific
+// XXX; S_EXCL  is OS-specific
 #define S_SEMI  &kp COMMA
 #define S_COLON &kp DOT
 #define S_QMARK &kp LS(M)
@@ -60,67 +60,68 @@
 // extra
 #define S_COMMA &kp M
 #define S_DOT   &kp LS(COMMA)
-#define S_MONEY &kp RA(E)
+// XXX; S_MONEY is OS-specific
 
-// "Apple AZERTY" differs significantly from the French PC variant
-#ifdef MACOS
-  #undef  S_MINUS
-  #define S_MINUS &kp EQUAL
-  #undef  S_UNDER
-  #define S_UNDER &kp LS(EQUAL)
-  #undef  S_EQUAL
-  #define S_EQUAL &kp FSLH
-  #undef  S_PLUS
-  #define S_PLUS  &kp LS(FSLH)
-  #undef  S_EXCL
-  #define S_EXCL  &kp N8
-  #undef  S_STAR
-  #define S_STAR  &kp LS(RBKT)
-  #undef  S_LBRC
-  #define S_LBRC  &kp RA(N5)
-  #undef  S_RBRC
-  #define S_RBRC  &kp RA(MINUS)
-  #undef  S_LBKT
-  #define S_LBKT  &kp SA(N5)
-  #undef  S_RBKT
-  #define S_RBKT  &kp SA(MINUS)
-  #undef  S_PIPE
-  #define S_PIPE  &kp SA(L)
-  #undef  S_CARET
-  #define S_CARET &digraph LBKT SPACE
-  #undef  S_TILDE
-  #define S_TILDE &digraph RA(N) SPACE
-  #undef  S_LT
-  #define S_LT    &kp GRAVE
-  #undef  S_GT
-  #define S_GT    &kp LS(GRAVE)
-  #undef  S_AT
-  #define S_AT    &kp NUBS
-  #undef  S_HASH
-  #define S_HASH  &kp PIPE2
-  #undef  S_BSLH
-  #define S_BSLH  &kp SA(DOT)
-  #undef  S_MONEY
-  #define S_MONEY &kp RA(RBKT)
-  #undef  S_GRAVE
-  #define S_GRAVE &digraph NUHS SPACE
-#endif
+/**
+ * OS_SELECT
+ */
 
-// GRAVE and TILDE are no dead keys on Linux
 #ifdef LINUX
-  #undef S_GRAVE
-  #define S_GRAVE &kp RA(N7)
-  #undef S_TILDE
-  #define S_TILDE &kp RA(N2)
+  #define OS_SELECT(i1, i2, i3, behavior) behavior
+#elifdef MACOS
+  #define OS_SELECT(i1, i2, behavior, i4) behavior
+#elifdef ENABLE_CP1252_ALT_CODES
+  #define OS_SELECT(i1, behavior, i3, i4) behavior
+#else
+  #define OS_SELECT(behavior, i2, i3, i4) behavior
 #endif
+
+#define DEAD_CIRCUMFLEX LBKT
+#define DEAD_DIAERESIS  LBRC
+#define DEAD_GRAVE OS_DEFINE(RA(N9), RA(N9), RA(N9), NUHS )
+#define DEAD_TILDE OS_DEFINE(RA(N2), RA(N2), RA(N2), RA(N))
+
+#define DK_CIR &kp DEAD_CIRCUMFLEX
+#define DK_DIA &kp DEAD_DIAERESIS
+#define DK_GRV &kp DEAD_GRAVE
+#define DK_TLD &kp DEAD_TILDE
+
+#define DI_CIR &digraph DEAD_CIRCUMFLEX
+#define DI_DIA &digraph DEAD_DIAERESIS
+#define DI_GRV &digraph DEAD_GRAVE
+#define DI_TLD &digraph DEAD_TILDE
+
+#define SA(key) RS(RA(key))
+
+//      symbol             default         CP1252          macOS           Linux
+#define S_CARET OS_SELECT( &kp RA(N9)    , &kp RA(N9)    , DI_CIR SPACE  , &kp RA(N9)    )
+#define S_LT    OS_SELECT( &kp NUBS      , &kp NUBS      , &kp GRAVE     , &kp NUBS      )
+#define S_GT    OS_SELECT( &kp PIPE2     , &kp PIPE2     , &kp TILDE     , &kp PIPE2     )
+#define S_AT    OS_SELECT( &kp RA(N0)    , &kp RA(N0)    , &kp NUBS      , &kp RA(N0)    )
+#define S_STAR  OS_SELECT( &kp BSLH      , &kp BSLH      , &kp RBRC      , &kp BSLH      )
+#define S_GRAVE OS_SELECT( DI_GRV SPACE  , DI_GRV SPACE  , DI_GRV SPACE  , &kp RA(N7)    )
+
+#define S_LBRC  OS_SELECT( &kp RA(N4)    , &kp RA(N4)    , &kp RA(N5)    , &kp RA(N4)    )
+#define S_RBRC  OS_SELECT( &kp RA(EQUAL) , &kp RA(EQUAL) , &kp RA(MINUS) , &kp RA(EQUAL) )
+#define S_BSLH  OS_SELECT( &kp RA(N8)    , &kp RA(N8)    , &kp SA(DOT)   , &kp RA(N8)    )
+#define S_PLUS  OS_SELECT( &kp PLUS      , &kp PLUS      , &kp QMARK     , &kp PLUS      )
+#define S_MINUS OS_SELECT( &kp N6        , &kp N6        , &kp EQUAL     , &kp N6        )
+
+#define S_TILDE OS_SELECT( DI_TLD SPACE  , DI_TLD SPACE  , DI_TLD SPACE  , &kp RA(N2)    )
+#define S_LBKT  OS_SELECT( &kp RA(N5)    , &kp RA(N5)    , &kp SA(N5)    , &kp RA(N5)    )
+#define S_RBKT  OS_SELECT( &kp RA(EQUAL) , &kp RA(EQUAL) , &kp SA(MINUS) , &kp RA(EQUAL) )
+#define S_UNDER OS_SELECT( &kp N8        , &kp N8        , &kp PLUS      , &kp N8        )
+#define S_HASH  OS_SELECT( &kp RA(N3)    , &kp RA(N3)    , &kp PIPE2     , &kp RA(N3)    )
+#define S_PIPE  OS_SELECT( &kp RA(N6)    , &kp RA(N6)    , &kp SA(L)     , &kp RA(N6)    )
+#define S_EXCL  OS_SELECT( &kp FSLH      , &kp FSLH      , &kp N8        , &kp FSLH      )
+
+#define S_MONEY OS_SELECT( &kp RA(E)     , &kp RA(E)     , &kp RA(RBKT)  , &kp RA(E)     )
 
 
 /**
  * Non-ASCII Symbols
  * https://commons.wikimedia.org/wiki/File:KB_-_AZERTY_-_FR_-_Windows_-_FR.png
  */
-
-#define SA(key) RS(RA(key))
 
 // lowercase: é à è ù ç
 #define C_EACU &kp N2  // é
@@ -151,32 +152,32 @@
 #endif
 
 // circumflex accent
-#define  C_ACRC &digraph LBKT Q     // â
-#define SC_ACRC &digraph LBKT RS(Q) // Â
-#define  C_ECRC &digraph LBKT E     // ê
-#define SC_ECRC &digraph LBKT RS(E) // Ê
-#define  C_ICRC &digraph LBKT I     // î
-#define SC_ICRC &digraph LBKT RS(I) // Î
-#define  C_OCRC &digraph LBKT O     // ô
-#define SC_OCRC &digraph LBKT RS(O) // Ô
-#define  C_UCRC &digraph LBKT U     // û
-#define SC_UCRC &digraph LBKT RS(U) // Û
-#define  C_YCRC &digraph LBKT Y     // ŷ
-#define SC_YCRC &digraph LBKT RS(Y) // Ŷ
+#define  C_ACRC DI_CIR Q     // â
+#define SC_ACRC DI_CIR RS(Q) // Â
+#define  C_ECRC DI_CIR E     // ê
+#define SC_ECRC DI_CIR RS(E) // Ê
+#define  C_ICRC DI_CIR I     // î
+#define SC_ICRC DI_CIR RS(I) // Î
+#define  C_OCRC DI_CIR O     // ô
+#define SC_OCRC DI_CIR RS(O) // Ô
+#define  C_UCRC DI_CIR U     // û
+#define SC_UCRC DI_CIR RS(U) // Û
+#define  C_YCRC DI_CIR Y     // ŷ
+#define SC_YCRC DI_CIR RS(Y) // Ŷ
 
 // diaeresis
-#define  C_ADIA &digraph LBRC A     // ä
-#define SC_ADIA &digraph LBRC RS(A) // Ä
-#define  C_EDIA &digraph LBRC E     // ë
-#define SC_EDIA &digraph LBRC RS(E) // Ë
-#define  C_IDIA &digraph LBRC I     // ï
-#define SC_IDIA &digraph LBRC RS(I) // Ï
-#define  C_ODIA &digraph LBRC O     // ö
-#define SC_ODIA &digraph LBRC RS(O) // Ö
-#define  C_UDIA &digraph LBRC U     // ü
-#define SC_UDIA &digraph LBRC RS(U) // Ü
-#define  C_YDIA &digraph LBRC Y     // ÿ
-#define SC_YDIA &digraph LBRC RS(Y) // Ÿ
+#define  C_ADIA DI_DIA A     // ä
+#define SC_ADIA DI_DIA RS(A) // Ä
+#define  C_EDIA DI_DIA E     // ë
+#define SC_EDIA DI_DIA RS(E) // Ë
+#define  C_IDIA DI_DIA I     // ï
+#define SC_IDIA DI_DIA RS(I) // Ï
+#define  C_ODIA DI_DIA O     // ö
+#define SC_ODIA DI_DIA RS(O) // Ö
+#define  C_UDIA DI_DIA U     // ü
+#define SC_UDIA DI_DIA RS(U) // Ü
+#define  C_YDIA DI_DIA Y     // ÿ
+#define SC_YDIA DI_DIA RS(Y) // Ÿ
 
 // other special letters: œ, æ, ß, ñ
 #ifdef LINUX

--- a/include/aekeynox/extra_layers/azerty_1dk.dtsi
+++ b/include/aekeynox/extra_layers/azerty_1dk.dtsi
@@ -22,9 +22,9 @@
     dead_key_layer {
       display-name = "1dk";
       bindings = <SELENIUM_KEYMAP_BINDINGS(
-        &trans  ,  C_AGRV  C_EACU  C_EGRV  C_EURO  &trans   ,  &trans  C_UGRV  &trans  C_OE    &trans  ,  &trans   ,
-        &trans  ,  C_ACRC  &trans  C_ECRC  S_MINUS S_UNDER  ,  &trans  C_UCRC  C_ICRC  C_OCRC  C_MICRO ,  &kp LBRC ,
-        &trans  ,  &trans  &trans  C_CCDL  S_LPAR  S_RPAR   ,  &trans  &trans  &trans  &trans  &trans  ,  &trans   ,
+        &trans  ,  C_AGRV  C_EACU  C_EGRV  C_EURO  &trans   ,  &trans  C_UGRV  &trans  C_OE    &trans  ,  &trans ,
+        &trans  ,  C_ACRC  &trans  C_ECRC  S_MINUS S_UNDER  ,  &trans  C_UCRC  C_ICRC  C_OCRC  C_MICRO ,  DK_DIA ,
+        &trans  ,  &trans  &trans  C_CCDL  S_LPAR  S_RPAR   ,  &trans  &trans  &trans  &trans  &trans  ,  &trans ,
                                   &trans , S_SQT , &trans   ,  &trans , S_SQT , &trans
       )>;
     };


### PR DESCRIPTION
As a first step towards #93, I’d like to experiment a macro to set key definitions depending on the OS:
- default = Windows or Android
- CP1252 = Windows with CP1252 alt codes
- macOS
- Linux

The French AZERTY is a good opportunity to test this.

@Nuclear-Squid I think you have some Zephyr preprocessing magic in mind to set default values in the `OS_DEFINE` macro?