### PR TITLE
chore: use consistent layout lists

### DIFF
--- a/include/aekeynox/aliases.h
+++ b/include/aekeynox/aliases.h
@@ -1,20 +1,39 @@
 #include <dt-bindings/zmk/keys.h>
+#include <dt-bindings/zmk/pointing.h>
 
-// PC / Mac
 
+/**
+ * Non-Alpha Actions
+ */
+
+// Keyboard Actions
 #ifdef MACOS
-  #define CMD LG // Mac: Cmd key as main modifier
+  #define CMD LG               // Mac: Cmd key as main modifier
+  #define X_PREV &kp LG(LBKT)
+  #define X_NEXT &kp LG(RBKT)
 #else
-  #define CMD LC // PC: Ctrl key as main modifier
+  #define CMD LC               // PC: Ctrl key as main modifier
+  #define X_PREV &kp LA(LEFT)
+  #define X_NEXT &kp LA(RIGHT)
 #endif
+#define X_SHTAB &kp RS(TAB)
 
-// Keyboard Layout
+// Mouse Actions
+#define ZMK_POINTING_DEFAULT_SCRL_VAL 25  // default=10 (too slow)
+#define X_MSC_L &msc SCRL_LEFT
+#define X_MSC_D &msc SCRL_DOWN
+#define X_MSC_U &msc SCRL_UP
+#define X_MSC_R &msc SCRL_RIGHT
 
-#ifdef KB_LAYOUT_QWERTY_INTL
-  #include "aliases/qwerty_intl.h"
-#elifdef KB_LAYOUT_DVORAK
-  #include "aliases/dvorak.h"
 
+/**
+ * Keyboard Layout
+ */
+
+// Non-US Layouts
+#ifdef KB_LAYOUT_AZERTY
+  #define SHIFTED_NUMBERS
+  #include "aliases/azerty.h"
 #elifdef KB_LAYOUT_QWERTY_BR
   #include "aliases/qwerty_br.h"
 #elifdef KB_LAYOUT_QWERTY_ES
@@ -23,31 +42,37 @@
   #include "aliases/qwerty_latam.h"
 #elifdef KB_LAYOUT_QWERTY_PT
   #include "aliases/qwerty_pt.h"
-#elifdef KB_LAYOUT_QWERTZ_DE
-  #include "aliases/qwertz_de.h"
 #elif defined KB_LAYOUT_QWERTZ_CH_DE || defined KB_LAYOUT_QWERTZ_CH_FR
   #include "aliases/qwertz_ch.h"
+#elifdef KB_LAYOUT_QWERTZ_DE
+  #include "aliases/qwertz_de.h"
 
-#elifdef KB_LAYOUT_AZERTY
-  #define SHIFTED_NUMBERS
-  #include "aliases/azerty.h"
-#elifdef KB_LAYOUT_QWERTY_LAFAYETTE
-  #include "aliases/qwerty_lafayette.h"
-#elifdef KB_LAYOUT_ERGOL
-  #include "aliases/ergol.h"
-#elifdef KB_LAYOUT_ERGLACE
-  #include "aliases/erglace.h"
+// Altenrative Layouts
 #elifdef KB_LAYOUT_BEPO
   #define SHIFTED_NUMBERS
   #include "aliases/bepo.h"
 #elifdef KB_LAYOUT_BEPOLAR
   #include "aliases/bepolar.h"
+#elifdef KB_LAYOUT_DVORAK
+  #include "aliases/dvorak.h"
+#elifdef KB_LAYOUT_ERGLACE
+  #include "aliases/erglace.h"
+#elifdef KB_LAYOUT_ERGOL
+  #include "aliases/ergol.h"
+#elifdef KB_LAYOUT_QWERTY_LAFAYETTE
+  #include "aliases/qwerty_lafayette.h"
 
+// US QWERTY
+#elifdef KB_LAYOUT_QWERTY_INTL
+  #include "aliases/qwerty_intl.h"
 #else
   #include "aliases/qwerty.h"
 #endif
 
-// Numbers
+
+/**
+ * Numbers
+ */
 
 #ifdef SHIFTED_NUMBERS
   #define S_N0  &kp LS(N0)
@@ -72,23 +97,3 @@
   #define S_N8  &kp N8
   #define S_N9  &kp N9
 #endif
-
-// Non-Alpha Actions
-
-#define X_SHTAB &kp RS(TAB)
-#ifdef MACOS
-  #define X_PREV &kp LG(LBKT)
-  #define X_NEXT &kp LG(RBKT)
-#else
-  #define X_PREV &kp LA(LEFT)
-  #define X_NEXT &kp LA(RIGHT)
-#endif
-
-// Mouse Actions
-#define ZMK_POINTING_DEFAULT_SCRL_VAL 25  // increase from the default 10 which is too slow
-#include <dt-bindings/zmk/pointing.h>
-
-#define X_MSC_L &msc SCRL_LEFT
-#define X_MSC_D &msc SCRL_DOWN
-#define X_MSC_U &msc SCRL_UP
-#define X_MSC_R &msc SCRL_RIGHT

--- a/include/aekeynox/aliases/azerty.h
+++ b/include/aekeynox/aliases/azerty.h
@@ -1,9 +1,11 @@
-#include <dt-bindings/zmk/keys.h>
-#include <zephyr/sys/util_macro.h>
+// France
+// https://kbdlayout.info/0000040c/
 
 /**
  * OS_SELECT
  */
+
+#include <zephyr/sys/util_macro.h>
 
 #define OS_SELECT_OR_DEFAULT(behavior, default) \
   COND_CODE_1(IS_EMPTY(behavior), (default), (behavior))
@@ -97,7 +99,6 @@
 
 /**
  * Non-ASCII Symbols
- * https://commons.wikimedia.org/wiki/File:KB_-_AZERTY_-_FR_-_Windows_-_FR.png
  */
 
 // lowercase: é à è ù ç

--- a/include/aekeynox/aliases/bepo.h
+++ b/include/aekeynox/aliases/bepo.h
@@ -1,4 +1,5 @@
-#include <dt-bindings/zmk/keys.h>
+// Bepo
+// https://bepo.fr
 
 /**
  * Action Combos

--- a/include/aekeynox/aliases/bepolar.h
+++ b/include/aekeynox/aliases/bepolar.h
@@ -1,4 +1,5 @@
-#include <dt-bindings/zmk/keys.h>
+// Bepolar
+// https://ergol.org/lafayette/#b%C3%A9polar
 
 /**
  * Action Combos

--- a/include/aekeynox/aliases/dvorak.h
+++ b/include/aekeynox/aliases/dvorak.h
@@ -1,4 +1,5 @@
-#include <dt-bindings/zmk/keys.h>
+// Dvorak (US)
+// https://kbdlayout.info/00010409/
 
 /**
  * Action Combos

--- a/include/aekeynox/aliases/erglace.h
+++ b/include/aekeynox/aliases/erglace.h
@@ -1,4 +1,5 @@
-#include <dt-bindings/zmk/keys.h>
+// Erglace
+// https://ergol.org/erglace/
 
 /**
  * Action Combos

--- a/include/aekeynox/aliases/ergol.h
+++ b/include/aekeynox/aliases/ergol.h
@@ -1,4 +1,5 @@
-#include <dt-bindings/zmk/keys.h>
+// Ergo-L
+// https://ergol.org
 
 /**
  * Action Combos

--- a/include/aekeynox/aliases/qwerty.h
+++ b/include/aekeynox/aliases/qwerty.h
@@ -1,4 +1,5 @@
-#include <dt-bindings/zmk/keys.h>
+// United States (ANSI)
+// https://kbdlayout.info/00000409/
 
 /**
  * Action Combos

--- a/include/aekeynox/aliases/qwerty_br.h
+++ b/include/aekeynox/aliases/qwerty_br.h
@@ -1,4 +1,5 @@
-#include <dt-bindings/zmk/keys.h>
+// Brazil (ABNT2)
+// https://kbdlayout.info/00010416/
 
 /**
  * Action Combos

--- a/include/aekeynox/aliases/qwerty_es.h
+++ b/include/aekeynox/aliases/qwerty_es.h
@@ -1,4 +1,30 @@
-#include <dt-bindings/zmk/keys.h>
+// Spain
+// https://kbdlayout.info/0000040a/
+
+/**
+ * Dead Keys
+ */
+
+#define DK_ACU &kp SQT  // acute
+#define DK_GRV &kp LBKT // grave
+#define DK_CIR &kp LBRC // circumflex
+#define DK_DIA &kp DQT  // diaeresis
+
+#define DEAD_ACUTE      &digraph SQT
+#define DEAD_GRAVE      &digraph LBKT
+#define DEAD_CIRCUMFLEX &digraph LBRC
+#define DEAD_DIAERESIS  &digraph DQT
+
+// tilde
+#ifdef LINUX
+  #define DEAD_TILDE &digraph RA(SEMI)
+  #define DK_TLD     &kp      RA(SEMI)
+  #define S_TILDE    &kp      RA(N4)
+#else
+  #define DEAD_TILDE &digraph RA(N4)
+  #define DK_TLD     &kp      RA(N4)
+  #define S_TILDE    DEAD_TILDE SPACE
+#endif
 
 /**
  * Action Combos
@@ -61,33 +87,6 @@
 #define S_COMMA &kp COMMA
 #define S_DOT   &kp DOT
 #define S_MONEY &kp RA(E)
-
-
-/**
- * Dead Keys
- */
-
-#define DK_ACU &kp SQT  // acute
-#define DK_GRV &kp LBKT // grave
-#define DK_CIR &kp LBRC // circumflex
-#define DK_DIA &kp DQT  // diaeresis
-
-#define DEAD_ACUTE      &digraph SQT
-#define DEAD_GRAVE      &digraph LBKT
-#define DEAD_CIRCUMFLEX &digraph LBRC
-#define DEAD_DIAERESIS  &digraph DQT
-
-// tilde
-#ifdef LINUX
-  #define DEAD_TILDE &digraph RA(SEMI)
-  #define DK_TLD     &kp      RA(SEMI)
-  #define S_TILDE    &kp      RA(N4)
-#else
-  #define DEAD_TILDE &digraph RA(N4)
-  #define DK_TLD     &kp      RA(N4)
-  #define S_TILDE    DEAD_TILDE SPACE
-#endif
-
 
 /**
  * Non-ASCII Symbols

--- a/include/aekeynox/aliases/qwerty_intl.h
+++ b/include/aekeynox/aliases/qwerty_intl.h
@@ -1,4 +1,5 @@
-#include <dt-bindings/zmk/keys.h>
+// United States (International)
+// https://kbdlayout.info/00020409/
 
 /**
  * Action Combos
@@ -61,7 +62,6 @@
 #define S_COMMA &kp COMMA
 #define S_DOT   &kp DOT
 #define S_MONEY &kp DLLR
-
 
 /**
  * Non-ASCII Symbols

--- a/include/aekeynox/aliases/qwerty_lafayette.h
+++ b/include/aekeynox/aliases/qwerty_lafayette.h
@@ -1,4 +1,5 @@
-#include <dt-bindings/zmk/keys.h>
+// QWERTY-Lafayette
+// https://qwerty-lafayette.org
 
 /**
  * Action Combos

--- a/include/aekeynox/aliases/qwerty_latam.h
+++ b/include/aekeynox/aliases/qwerty_latam.h
@@ -1,4 +1,21 @@
-#include <dt-bindings/zmk/keys.h>
+// Latin America
+// https://kbdlayout.info/0000080a/
+
+/**
+ * Dead Keys
+ */
+
+#define DK_ACU &kp LBKT     // acute
+#define DK_GRV &kp RA(BSLH) // grave
+#define DK_CIR &kp RA(SQT)  // circumflex
+#define DK_DIA &kp LBRC     // diaeresis
+#define DK_TLD &none        // tilde (unsupported)
+
+#define DEAD_ACUTE      &digraph LBKT
+#define DEAD_GRAVE      &digraph RA(BSLH)
+#define DEAD_CIRCUMFLEX &digraph RA(SQT)
+#define DEAD_DIAERESIS  &digraph LBRC
+#define DEAD_TILDE      &kp
 
 /**
  * Action Combos
@@ -61,23 +78,6 @@
 #define S_COMMA &kp COMMA
 #define S_DOT   &kp DOT
 #define S_MONEY &kp RA(E)
-
-
-/**
- * Dead Keys
- */
-
-#define DK_ACU &kp LBKT     // acute
-#define DK_GRV &kp RA(BSLH) // grave
-#define DK_CIR &kp RA(SQT)  // circumflex
-#define DK_DIA &kp LBRC     // diaeresis
-#define DK_TLD &none        // tilde (unsupported)
-
-#define DEAD_ACUTE      &digraph LBKT
-#define DEAD_GRAVE      &digraph RA(BSLH)
-#define DEAD_CIRCUMFLEX &digraph RA(SQT)
-#define DEAD_DIAERESIS  &digraph LBRC
-#define DEAD_TILDE      &kp
 
 /**
  * Non-ASCII Symbols

--- a/include/aekeynox/aliases/qwerty_pt.h
+++ b/include/aekeynox/aliases/qwerty_pt.h
@@ -1,4 +1,5 @@
-#include <dt-bindings/zmk/keys.h>
+// Portugal
+// https://kbdlayout.info/00000816/
 
 /**
  * Action Combos

--- a/include/aekeynox/aliases/qwertz_ch.h
+++ b/include/aekeynox/aliases/qwertz_ch.h
@@ -1,4 +1,5 @@
-#include <dt-bindings/zmk/keys.h>
+// Switzerland
+// https://kbdlayout.info/00000807/
 
 /**
  * Action Combos
@@ -13,6 +14,16 @@
 #define X_CTL_W &kp LC(W)
 #define X_SAVE  &kp CMD(S)
 #define X_ALL   &kp CMD(A)
+
+/**
+ * Dead Keys
+ */
+
+#define DK_CIR &kp EQUAL     // circumflex
+#define DK_ACU &kp MINUS     // acute
+#define DK_GRV &kp PLUS      // grave
+#define DK_DIA &kp RBKT      // diaeresis
+#define DK_TLD &kp RA(EQUAL) // tilde
 
 /**
  * Arsenik Symbols:
@@ -61,18 +72,6 @@
 #define S_COMMA &kp COMMA
 #define S_DOT   &kp DOT
 #define S_MONEY &kp RA(E)
-
-
-/**
- * Dead Keys
- */
-
-#define DK_CIR &kp EQUAL     // circumflex
-#define DK_ACU &kp MINUS     // acute
-#define DK_GRV &kp PLUS      // grave
-#define DK_DIA &kp RBKT      // diaeresis
-#define DK_TLD &kp RA(EQUAL) // tilde
-
 
 /**
  * Non-ASCII Symbols

--- a/include/aekeynox/aliases/qwertz_de.h
+++ b/include/aekeynox/aliases/qwertz_de.h
@@ -1,4 +1,5 @@
-#include <dt-bindings/zmk/keys.h>
+// Germany, Austria
+// https://kbdlayout.info/00000407/
 
 /**
  * Action Combos
@@ -13,6 +14,14 @@
 #define X_CTL_W &kp LC(W)
 #define X_SAVE  &kp CMD(S)
 #define X_ALL   &kp CMD(A)
+
+/**
+ * Dead Keys
+ */
+
+#define DK_CIR &kp GRAVE  // circumflex
+#define DK_ACU &kp EQUAL  // acute
+#define DK_GRV &kp PLUS   // grave
 
 /**
  * Arsenik Symbols:
@@ -61,16 +70,6 @@
 #define S_COMMA &kp COMMA
 #define S_DOT   &kp DOT
 #define S_MONEY &kp RA(E)
-
-
-/**
- * Dead Keys
- */
-
-#define DK_CIR &kp GRAVE  // circumflex
-#define DK_ACU &kp EQUAL  // acute
-#define DK_GRV &kp PLUS   // grave
-
 
 /**
  * Non-ASCII Symbols

--- a/include/aekeynox/extra_layers/README.md
+++ b/include/aekeynox/extra_layers/README.md
@@ -20,15 +20,15 @@ When possible, it’s placed on the `SEMI` key (QWERTY’s <kbd>;:</kbd> key).
   - [Nordic](#nordic-todo) (Danish, Estonian, Faroese, Finnish, Icelandic, Norwegian, Swedish)
   - [Transalp](#transalp) (French, German, Italian)
   - [Transat](#transat-todo) (Portuguese, Spanish, Aranese, Basque, Catalan, Galician)
-- [Programmer’s QWERTY](#programmers-qwerty)
 - [Layout-Specific Adaptations](#layout-specific-adaptations)
   - [AZERTY-1dk](#azerty-1dk-french)
   - [Bépolar](#bépolar-french)
   - [Other Layouts](#other-layouts)
+- [Programmer’s QWERTY](#programmers-qwerty)
 - [Six-Column Configurations](#six-column-configurations)
   - [QWERTY-intl](#qwerty-intl)
   - [Non-US QWERTY and QWERTZ](#non-us-qwerty-and-qwertz)
-- [Ressources](#ressources)
+- [Resources](#resources)
 
 
 Multilingual Adaptations
@@ -37,12 +37,15 @@ Multilingual Adaptations
 Most West-European languages can be supported by three 1dk layers: Nordic,
 Transalp, Transat. They can be used either on QWERTY or QWERTZ.
 
-### Nordic (TODO)
+### Nordic
 
 Recommended layouts:
 
-- QWERTY: Denmark, Iceland, Norway, Sweden/Finland/Estonia
-- QWERTZ: Germany/Austria
+- [ ] QWERTY-dk: Denmark
+- [ ] QWERTY-is: Iceland
+- [ ] QWERTY-no: Norway
+- [ ] QWERTY-se: Sweden, Finland, Estonia (?)
+- [ ] QWERTZ-de: Germany, Austria
 
 ```
     |---------------|---------------|  base
@@ -66,10 +69,10 @@ Recommended layouts:
 
 Supported languages:
 
-- Swedish, Finnish, Estonian:  `å`, `ä`, `ö`
-- Danish, Norwegian:           `å`, `æ`, `ø`
-- Faroese:                     `å`, `æ`, `ø`, `ð`
-- Icelandic:                   `þ`, `æ`, `ö`, `ð`, `áéíóúý` (+ diaeresis?)
+- [ ] Swedish, Finnish, Estonian:  `å`, `ä`, `ö`
+- [ ] Danish, Norwegian:           `å`, `æ`, `ø`
+- [ ] Faroese:                     `å`, `æ`, `ø`, `ð`
+- [ ] Icelandic:                   `þ`, `æ`, `ö`, `ð`, `áéíóúý` (+ diaeresis?)
 
 This might be suitable for [Dutch](https://en.wikipedia.org/wiki/Dutch_orthography) as well:
 
@@ -82,9 +85,9 @@ This might be suitable for [Dutch](https://en.wikipedia.org/wiki/Dutch_orthograp
 
 Recommended layouts:
 
-- QWERTZ-ch: Switzerland, Luxembourg and Lichtenstein
-- QWERTZ-de: Germany, Austria
-- QWERTY-it: Italy (TODO)
+- [x] QWERTZ-ch: Switzerland, Luxembourg, Liechtenstein
+- [x] QWERTZ-de: Germany, Austria
+- [ ] QWERTY-it: Italy
 
 ```
     |---------------|---------------|  base
@@ -108,13 +111,18 @@ Recommended layouts:
 
 Supported languages:
 
-- German: `äöü` (diaeresis), `ß`
-- French: `é` (acute), `èàù` (grave), `ç` (cedilla), `âêîôû` (circumflex), `ëïüÿ` (diaeresis)
-- Italian: `é` (acute), `àèìòù` (grave)
+- [x] German: `äöü` (diaeresis), `ß`
+- [x] French: `é` (acute), `èàù` (grave), `ç` (cedilla), `âêîôû` (circumflex), `ëïüÿ` (diaeresis)
+- [x] Italian: `é` (acute), `àèìòù` (grave)
 
 ### Transat
 
-Recommended layouts: Brazilian, Latam, Portuguese, Spanish.
+Recommended layouts:
+
+- [x] QWERTY-br: Brazil
+- [x] QWERTY-latam: Latin America
+- [x] QWERTY-es: Spain
+- [x] QWERTY-pt: Portugal
 
 ```
     |---------------|---------------|  base
@@ -138,27 +146,11 @@ Recommended layouts: Brazilian, Latam, Portuguese, Spanish.
 
 Supported languages (specific diacritics beside `ñ`, `ç` and `áéíóú`):
 
-- Portuguese: `à`, `ã`, `õ`, `^` (+ `ü`, deprecated)
-- Catalan:    `è`, `ò`, `ï`, `·`
-- Aranese:    `à`, `è`, `ò`
-- Galician:   none?
-- Basque:     none
-
-
-Programmer’s QWERTY
---------------------------------------------------------------------------------
-
-Many European languages in central or eastern Europe have a “Programmer’s QWERTY”
-variant, with a QWERTY-ANSI base layer and special chars in an secondary layer
-(often AltGr). This seems to be a natural fit for ergonomic keyboards.
-
-However:
-
-- some of these layouts cannot fit on a 3×10 grid, and require an adaptation;
-- an option to replace the `SEMI` key by a dead AtlGr could be nice.
-
-If you use such a layout, please open a ticket and we’ll propose a dedicated
-adaptation.
+- [x] Portuguese: `à`, `ã`, `õ`, `^` (+ `ü`, deprecated)
+- [x] Catalan:    `è`, `ò`, `ï`, `·`
+- [x] Aranese:    `à`, `è`, `ò`
+- [x] Galician:   none (?)
+- [x] Basque:     none
 
 
 Layout-Specific Adaptations
@@ -232,6 +224,22 @@ If you use one of these layouts, please open a ticket and we’ll work something
 out.
 
 
+Programmer’s QWERTY
+--------------------------------------------------------------------------------
+
+Many European languages in central or eastern Europe have a “Programmer’s QWERTY”
+variant, with a QWERTY-ANSI base layer and special chars in an secondary layer
+(often AltGr). This seems to be a natural fit for ergonomic keyboards.
+
+However:
+
+- some of these layouts cannot fit on a 3×10 grid, and require an adaptation;
+- an option to replace the `SEMI` key by a dead AltGr could be nice.
+
+If you use such a layout, please open a ticket and we’ll propose a dedicated
+adaptation.
+
+
 Six-Column Configurations
 --------------------------------------------------------------------------------
 
@@ -274,11 +282,11 @@ With this, `ÖÄÜ` can now be accessed directly — though with a lateral exten
 of the pinky. `ẞ` is missing, but `/include/aekeynox/outer_keys.h` could be
 customized to include it under the left pinky.
 
-We still (highly) recommend using a `1dk` layer instead (both `nordic` and
-`transalp` work fine with German); but *your keyboard, your rules!*
+We still (highly) recommend using a `1dk` layer instead (both `Nordic` and
+`Transalp` work fine with German); but *your keyboard, your rules!*
 
 
-Ressources
+Resources
 --------------------------------------------------------------------------------
 
 - [kbdlayout.info](https://kbdlayout.info/) for Windows

--- a/tests.yaml
+++ b/tests.yaml
@@ -10,12 +10,12 @@ include:
     artifact-name: default
     cmake-args: -DDTS_EXTRA_CPPFLAGS="-DCI_IGNORE_USER_SETTINGS"
 
-    # Qwerty + thumb-taps
+    # QWERTY + thumb-taps
   - board: quacken_flex/rp2040
     artifact-name: qwerty_tt
     cmake-args: -DDTS_EXTRA_CPPFLAGS="-DCI_IGNORE_USER_SETTINGS;-DHT_THUMB_TAPS"
 
-    # Qwerty + Vim + hrm_shift
+    # QWERTY + Vim + hrm_shift
   - board: quacken_flex/rp2040
     artifact-name: qwerty_vim_shift
     cmake-args: -DDTS_EXTRA_CPPFLAGS="-DCI_IGNORE_USER_SETTINGS;-DVIM_NAVIGATION;-DHRM_SHIFT"
@@ -34,47 +34,47 @@ include:
   # Layout Adaptations
   ##
 
-    # Azerty
+    # AZERTY (France)
   - board: quacken_flex/rp2040
     artifact-name: azerty
     cmake-args: -DDTS_EXTRA_CPPFLAGS="-DCI_IGNORE_USER_SETTINGS;-DKB_LAYOUT_AZERTY"
 
-    # Bepo
+    # Bepo (France)
   - board: quacken_flex/rp2040
     artifact-name: bepo
     cmake-args: -DDTS_EXTRA_CPPFLAGS="-DCI_IGNORE_USER_SETTINGS;-DKB_LAYOUT_BEPO"
 
-    # Qwerty-intl
-  - board: quacken_flex/rp2040
-    artifact-name: qwerty_intl
-    cmake-args: -DDTS_EXTRA_CPPFLAGS="-DCI_IGNORE_USER_SETTINGS;-DKB_LAYOUT_QWERTY_INTL;-DUSE_ALPHA_ON_OUTER_KEYS"
-
-    # Qwerty (br)
+    # QWERTY-br (Brazil)
   - board: quacken_flex/rp2040
     artifact-name: qwerty_br
     cmake-args: -DDTS_EXTRA_CPPFLAGS="-DCI_IGNORE_USER_SETTINGS;-DKB_LAYOUT_QWERTY_BR"
 
-    # Qwerty (es)
+    # QWERTY-es (Spain)
   - board: quacken_flex/rp2040
     artifact-name: qwerty_es
     cmake-args: -DDTS_EXTRA_CPPFLAGS="-DCI_IGNORE_USER_SETTINGS;-DKB_LAYOUT_QWERTY_ES"
 
-    # Qwerty (latam)
+    # QWERTY-intl (US-International)
+  - board: quacken_flex/rp2040
+    artifact-name: qwerty_intl
+    cmake-args: -DDTS_EXTRA_CPPFLAGS="-DCI_IGNORE_USER_SETTINGS;-DKB_LAYOUT_QWERTY_INTL;-DUSE_ALPHA_ON_OUTER_KEYS"
+
+    # QWERTY-latam (Latin America)
   - board: quacken_flex/rp2040
     artifact-name: qwerty_latam
     cmake-args: -DDTS_EXTRA_CPPFLAGS="-DCI_IGNORE_USER_SETTINGS;-DKB_LAYOUT_QWERTY_LATAM"
 
-    # Qwerty (pt)
+    # QWERTY-pt (Portugal)
   - board: quacken_flex/rp2040
     artifact-name: qwerty_pt
     cmake-args: -DDTS_EXTRA_CPPFLAGS="-DCI_IGNORE_USER_SETTINGS;-DKB_LAYOUT_QWERTY_PT"
 
-    # Qwertz (ch)
+    # QWERTZ-ch (Switzerland)
   - board: quacken_flex/rp2040
     artifact-name: qwertz_ch_de
     cmake-args: -DDTS_EXTRA_CPPFLAGS="-DCI_IGNORE_USER_SETTINGS;-DKB_LAYOUT_QWERTZ_CH_DE"
 
-    # Qwertz (de)
+    # QWERTZ-de (Germany)
   - board: quacken_flex/rp2040
     artifact-name: qwertz_de
     cmake-args: -DDTS_EXTRA_CPPFLAGS="-DCI_IGNORE_USER_SETTINGS;-DKB_LAYOUT_QWERTZ_DE"
@@ -83,37 +83,37 @@ include:
   # Layout Emulations
   ##
 
-    # Colemak on Qwerty
+    # Colemak on QWERTY
   - board: quacken_flex/rp2040
     artifact-name: qwerty_to_colemak
     cmake-args: -DDTS_EXTRA_CPPFLAGS="-DCI_IGNORE_USER_SETTINGS;-DKB_LAYOUT_QWERTY;-DKB_EMULATION_COLEMAK"
 
-    # Colemak-DH on Qwerty
+    # Colemak-DH on QWERTY
   - board: quacken_flex/rp2040
     artifact-name: qwerty_to_colemak_dh
     cmake-args: -DDTS_EXTRA_CPPFLAGS="-DCI_IGNORE_USER_SETTINGS;-DKB_LAYOUT_QWERTY;-DKB_EMULATION_COLEMAK_DH"
 
-    # Dvorak on Qwerty
+    # Dvorak on QWERTY
   - board: quacken_flex/rp2040
     artifact-name: qwerty_to_dvorak
     cmake-args: -DDTS_EXTRA_CPPFLAGS="-DCI_IGNORE_USER_SETTINGS;-DKB_LAYOUT_QWERTY;-DKB_EMULATION_DVORAK"
 
-    # Ergol on Azerty
+    # Ergol on AZERTY
   - board: quacken_flex/rp2040
     artifact-name: azerty_to_ergol
     cmake-args: -DDTS_EXTRA_CPPFLAGS="-DCI_IGNORE_USER_SETTINGS;-DKB_LAYOUT_AZERTY;-DKB_EMULATION_ERGOL"
 
-    # Ergol on Qwerty-intl
+    # Ergol on QWERTY-intl
   - board: quacken_flex/rp2040
     artifact-name: qwerty_intl_to_ergol
     cmake-args: -DDTS_EXTRA_CPPFLAGS="-DCI_IGNORE_USER_SETTINGS;-DKB_LAYOUT_QWERTY_INTL;-DKB_EMULATION_ERGOL"
 
-    # Lafayette on Azerty
+    # Lafayette on AZERTY
   - board: quacken_flex/rp2040
     artifact-name: azerty_to_lafayette
     cmake-args: -DDTS_EXTRA_CPPFLAGS="-DCI_IGNORE_USER_SETTINGS;-DKB_LAYOUT_AZERTY;-DKB_EMULATION_QWERTY_LAFAYETTE"
 
-    # Lafayette on Qwerty-intl
+    # Lafayette on QWERTY-intl
   - board: quacken_flex/rp2040
     artifact-name: qwerty_intl_to_lafayette
     cmake-args: -DDTS_EXTRA_CPPFLAGS="-DCI_IGNORE_USER_SETTINGS;-DKB_LAYOUT_QWERTY_INTL;-DKB_EMULATION_QWERTY_LAFAYETTE"


### PR DESCRIPTION
As more and more keyboard layouts are supported, it's time to settle for a consistent way to list and name them.

- AZERTY, QWERTY, QWERTZ should be in full-caps
- the country/region ID should match the XKeyboardConfig ID
- layouts should be listed in alphabetical order, but may be grouped by catégories: national layouts, alternative layouts...