### PR TITLE
doc: aliases and layouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# Ækeynox
+Ækeynox
+====================================================================================================
 
 Reference ZMK implementation of the [Arsenik] and [Selenium] keymaps,
 with first-class support for non-QWERTY layouts.
@@ -20,8 +21,11 @@ with first-class support for non-QWERTY layouts.
 
 Customize your keymap once, and build it on all supported keebs.
 
+[Check the configuration guide.](include/aekeynox#readme)
 
-## In a Nutshell
+
+In a Nutshell
+----------------------------------------------------------------------------------------------------
 
 This repository allows to build your firmware with GitHub Actions (GHA):
 
@@ -49,32 +53,33 @@ with the `settings_reset` firmware matching your controller.
 More info [in the ZMK documentation](https://zmk.dev/docs/troubleshooting/connection-issues).
 
 
-## Configuration
+Configuration
+----------------------------------------------------------------------------------------------------
 
-### `include/aekeynox/settings.h`
+### Keymap Customization: [`include/aekeynox/`](include/aekeynox)
 
-This is where options can be safely selected. This file should be self-explanatory,
-but here are the main options:
+This is where your keymap options can be safely selected:
 
-- `KB_LAYOUT_*` must match the layout used on the host computer
-- `KB_EMULATION_*` activates a [layout emulation](#layout-emulation) (none by default)
-- `HT_*` selects the Selenium hold-tap flavor: [EZ], [TT], [HRM] (default), [2TK]
-- `VIM_NAVIGATION` enables the [Vim variant]
+- which keyboard layout you use:
+  - either by setting your keeb for the layout on the host computer
+  - or by [emulating a keyboard layout](include/aekeynox/emulations#readme)
+    on devices running the local default layout (computers, tablets, phones…)
 
-**Setting `KB_LAYOUT_*` is required when the host computer is not set in US QWERTY.**
-This setting is used to pick the proper file in `include/aekeynox/aliases`, which defines
-how all programming symbols and action shortcuts are done.
+- which hold-tap flavor you prefer:
+  - [HRM] is assumed by default, and is recommended for experienced users
+  - when unsure, you can go step-by-step and begin with [EZ] or [TT] before switching to [HRM]
 
-If unset, QWERTY is assumed, which **will** result in buggy `Symbols` and `Nav` layers
-when the host computer is configured for a different keyboard layout.
+- and all your personal options: Vim navigation, Callum mods…
 
-### `include/aekeynox/selenium.keymap`
+[Check the configuration guide.](include/aekeynox#readme)
 
-This file allows low-level customization.
+### Keyboard Descriptors: [`config/*.keymap`](config)
 
-See the [customizing ZMK](https://zmk.dev/docs/customization) documentation.
+This is where you can add a new keyboard, or redefine an existing keyboard.
 
-### `build.yaml`
+A few keyboards expose hardware-level options in `config/*.conf` files.
+
+### [`build.yaml`](build.yaml)
 
 This is the list of all keyboard firmware to build.
 
@@ -88,70 +93,35 @@ You might have to change the `board` field to match the micro-controller unit as
 
 If your keeb has an onboard controller, there’s nothing to configure.
 
-### `config/*.keymap`
 
-These are the keyboard descriptors. The folder name can be confusing, but that’s how ZMK works.
+Non-ASCII Layouts
+----------------------------------------------------------------------------------------------------
 
+Using non-ASCII layouts can be very frustrating on ergonomic keyboards. Many users opt for a 4×6
+model, thinking it will be easier to use, but these big keebs are only marginally simpler, and they
+break the holy 1DFH rule: *“1u Distance From Home”*. 3×6 and 3×5 keebs are much more comfortable,
+and just as easy with non-ASCII layouts.
 
-## Layout Emulation
+Ækeynox aims to support all major variants of AZERTY, QWERTY, QWERTZ and more.
+It has sane presets for European languages, relying on a simple concept:
 
-Using a non-QWERTY layout can be done in two ways:
+- the 3×10 grid is dedicated to the common AZERTY / QWERTY / QWERTZ basis, extra columns are
+  reserved for special keys (Escape, Enter…);
+- one key on the 3×10 grid (usually the rightmost key in the home row) is turned into a one-shot
+  layer key, to access all your language-specific chars;
+- Ækeynox already has several pre-defined extra layers, which have been carefully optimized to
+  match your language.
 
-- either by setting the host computer to use this layout, in which case `KB_LAYOUT_*` is enough
-  (see above);
-- or by letting the keyboard *emulate* a keyboard layout for a host using a default layout
-  — and that’s what `KB_EMULATION_*` is about.
+The idea comes from the [QWERTY-1dk](https://github.com/OneDeadKey/1dk) project, which has been used
+for almost a decade now.
+The result is much easier to use than any full-size European or Latin American layout.
 
-### ASCII Layouts
-
-Keyboard layouts that are optimized for English are just a rearrangement of QWERTY keys:
-Dvorak, Colemak, Workman, Sturdy… all these layouts can be perfectly emulated by the keyboard.
-
-To emulate Dvorak for QWERTY hosts, just uncomment this line in `include/aekeynox/settings.h`:
-
-```c
-#define KB_EMULATION_DVORAK
-```
-
-### Non-ASCII Layouts
-
-Emulating layouts designed for other languages is trickier.
-
-First, a keyboard layout with extended characters is required on the host computer.
-That’s our emulation target.
-
-- [QWERTY-intl] is a sane default for west-European languages. It’s available on every computer,
-  it just has to be enabled.
-- Local layouts (AZERTY, QWERTZ, non-US QWERTY variants…) are good emulation targets as well.
-  Not as versatile as QWERTY-intl, but they’re the local default.
-
-As an example, to emulate Ergol for AZERTY hosts, uncomment these two lines:
-
-```c
-#define KB_LAYOUT_AZERTY
-#define KB_EMULATION_ERGOL
-```
-
-Now, here’s the tricky part:
-these non-US layouts are likely to differ significantly across Windows, macOS, Linux.
-QWERTY-intl is probably the most consistent one, but it still comes with minor differences.
-
-By default, Ækeynox assumes the lowest common character subset, which is provided by Windows layouts.
-This ensures your keeb will work consistently across all major platforms. But unless you need your
-keyboard to be usable with *any* OS, you’ll have a better experience by activating OS-specific options:
-
-- either by selecting the `MACOS` or `LINUX` option, if that’s the targeted host OS;
-- or by selecting the `ENABLE_CP1252_ALT_CODES` option, which leverages Windows’ [Alt-Codes].
-
-The emulation of non-ASCII layouts is being actively developed.
-It’s already used as a daily driver by some of our European contributors.
-Feedback and patches are very welcome.
-
-[QWERTY-intl]: https://commons.wikimedia.org/wiki/File:KB_US-International.svg
-[Alt-Codes]:   https://altcodeunicode.com/
+- [Supported host layouts](include/aekeynox/aliases#readme)
+- [Proposed layout adaptations](include/aekeynox/extra_layers#readme)
 
 
-## Why the name?
+Why the name?
+----------------------------------------------------------------------------------------------------
 
 Any name containing `key` and easy to search would’ve been a good fit, but here’s Nox:
 

--- a/include/aekeynox/README.md
+++ b/include/aekeynox/README.md
@@ -1,0 +1,53 @@
+Keymap Configuration Guide
+====================================================================================================
+
+
+[`settings.h`](settings.h)
+----------------------------------------------------------------------------------------------------
+
+This is where options can be safely selected. This file should be self-explanatory,
+but here’s the big picture.
+
+### Host Keyboard Layout
+
+`KB_LAYOUT_*` must match the layout used on the host computer.
+
+**Setting `KB_LAYOUT_*` is required when the host computer is not set in US QWERTY.**
+This setting is used to pick the proper [`aliases/*.h`](aliases) file,
+which defines how all programming symbols and action shortcuts are done.
+
+If unset, QWERTY is assumed, which **will** result in buggy `Symbols` and `Nav` layers
+when the host computer is configured for a different keyboard layout.
+
+### Onboard Layout Emulation
+
+`KB_EMULATION_*` activates a [layout emulation](#layout-emulation) (none by default).
+
+### Hold-Taps
+
+`HT_*` selects the [Selenium] hold-tap flavor:
+
+- [EZ]  / `HT_NONE`: no hold-taps at all, for gamers or absolute beginners
+- [TT]  / `HT_THUMB_TAPS`: thumb-taps, a good option to get started with standard keyboards
+- [HRM] / `HT_HOME_ROW_MODS`: home row mods — this is the default and recommended flavor for experienced users
+- [2TK] / `HT_TWO_THUMB_KEYS`: home row mods on smaller keebs that have only two keys per thumb
+
+[Selenium]:    https://onedeadkey.github.io/selenium
+[EZ]:          https://onedeadkey.github.io/selenium/#flavor-ez
+[TT]:          https://onedeadkey.github.io/selenium/#flavor-tt
+[HRM]:         https://onedeadkey.github.io/selenium/#flavor-hrm
+[2TK]:         https://onedeadkey.github.io/selenium/#flavor-2tk
+[Vim variant]: https://onedeadkey.github.io/selenium/#vim-variant
+
+### Other Options
+
+- `VIM_NAVIGATION` enables the [Vim variant]
+- `CALLUM_NAVIGATION` enables a variant of the `VIM_NAVIGATION` layer with Callum-mods
+
+
+[`selenium.keymap`](selenium.keymap)
+----------------------------------------------------------------------------------------------------
+
+This file allows low-level customization.
+
+See the [customizing ZMK](https://zmk.dev/docs/customization) documentation.

--- a/include/aekeynox/aliases/README.md
+++ b/include/aekeynox/aliases/README.md
@@ -1,0 +1,120 @@
+Layout Aliasess
+================================================================================
+
+Every Ækeynox firmware is built for a specific host keyboard layout, i.e. the
+layout that the host computer is configured for. (If this sentence makes no
+sense to you, the host layout is probably US QWERTY, and you can skip the rest
+of this file.)
+
+- This is absolutely necessary to define the Symbols layer.
+- This is nice to have for a few shortcuts in the Nav layer (cut, copy, paste…).
+- This is required to handle non-ASCII layout adaptations and emulations.
+
+This `aliases` directory contains the definitions of actions and symbols for each
+host layout. This is trickier than it should be, because these non-ASCII layouts
+can differ significantly from an OS to another, or have local variants. Even
+[QWERTY-intl](qwerty_intl.h) has major differences between Windows, macOS and
+Linux.
+
+
+Supported Layouts
+--------------------------------------------------------------------------------
+
+Ækeynox aims to support the most common standard layouts. As a rule of thumb,
+this starts with layouts that have a dedicated Apple keyboard, plus a couple
+others:
+
+| ☑  | Layout ID                | Used in…                          | Variant     |
+|:--:|--------------------------|-----------------------------------|-------------|
+| ✅ | `KB_LAYOUT_QWERTY`       | United States                     |
+| ✅ | `KB_LAYOUT_QWERTY_INTL`  | United States / International     |
+|    |
+| ✅ | `KB_LAYOUT_AZERTY`       | France                            |
+| 💡 | `KB_LAYOUT_AZERTY_BE`    | Belgium                           |
+|    |
+| ✅ | `KB_LAYOUT_QWERTY_BR`    | Brazil                            |
+| 💡 | `KB_LAYOUT_QWERTY_CA`    | Canada                            | Multilingual
+| 💡 | `KB_LAYOUT_QWERTY_CZ`    | Czech Republic                    | Programmers
+| 🚧 | `KB_LAYOUT_QWERTY_DK`    | Denmark                           |
+| ✅ | `KB_LAYOUT_QWERTY_ES`    | Spain                             |
+| 💡 | `KB_LAYOUT_QWERTY_HR`    | Bosnia, Croatia, Serbia, Slovenia |
+| 💡 | `KB_LAYOUT_QWERTY_HU`    | Hungary                           | 101-key
+| ✅ | `KB_LAYOUT_QWERTY_IT`    | Italy                             | 142
+| 🚧 | `KB_LAYOUT_QWERTY_IS`    | Iceland                           |
+| ✅ | `KB_LAYOUT_QWERTY_LATAM` | Latin America                     |
+| 💡 | `KB_LAYOUT_QWERTY_NL`    | Netherlands                       |
+| 🚧 | `KB_LAYOUT_QWERTY_NO`    | Norway                            |
+| 💡 | `KB_LAYOUT_QWERTY_PL`    | Poland                            | Programmers
+| ✅ | `KB_LAYOUT_QWERTY_PT`    | Portugal                          |
+| 💡 | `KB_LAYOUT_QWERTY_RO`    | Romania                           | Standard
+| 🚧 | `KB_LAYOUT_QWERTY_SE`    | Sweden, Finland                   |
+| 💡 | `KB_LAYOUT_QWERTY_TR`    | Turkey                            |
+|    |
+| ✅ | `KB_LAYOUT_QWERTZ_CH_DE` | Switzerland                       | German
+| ✅ | `KB_LAYOUT_QWERTZ_CH_FR` | Switzerland                       | French
+| 💡 | `KB_LAYOUT_QWERTZ_CZ`    | Czech Republic                    |
+| ✅ | `KB_LAYOUT_QWERTZ_DE`    | Germany, Austria                  |
+| 💡 | `KB_LAYOUT_QWERTZ_HU`    | Hungary                           |
+| 💡 | `KB_LAYOUT_QWERTZ_SK`    | Slovakia                          |
+
+Ækeynox also aims to support a few alternative layouts, especially the non-ASCII
+ones:
+
+- [x] KB_LAYOUT_BEPO
+- [x] KB_LAYOUT_DVORAK
+- [x] KB_LAYOUT_ERGOL
+- [x] KB_LAYOUT_QWERTY_LAFAYETTE
+- [ ] KB_LAYOUT_NEO
+
+
+OS-Specific Considerations
+--------------------------------------------------------------------------------
+
+Non-ASCII layouts can differ significantly from an OS to another.
+Even [QWERTY-intl](qwerty_intl.h) has major differences between Windows, macOS
+and Linux.
+
+### Windows
+
+Windows is considered as the *de facto* reference: it’s well documented, it’s
+printed on all non-Apple keyboards in the world, and any keyboard connected
+to an Android device is considered as a Windows keyboard.
+
+The main limitation is that these layouts support fewer non-ASCII characters
+than their macOS or Linux counterparts. Some layouts even lack letters that are
+part of the local alphabet, e.g. `Œ` (French ) for AZERTY, `ŀ` (Catalan) for
+QWERTY-es, uppercase accented chars for AZERTY and QWERTY-it…
+
+Some of the missing chars for Western European languages can be accessed by
+[CP1252 alt codes](https://altcodeunicode.com/) (works with any Windows app).
+
+Reference: [kbdlayout.info]
+
+### macOS
+
+Apple often modifies existing national layouts to their liking, and sometimes
+use the same modified layout for several different countries:
+
+- their AZERTY is shipped to both France and Belgium, and it’s *far* from the
+  local Windows versions;
+- their QWERTY-ro is specific to Romania, but it’s neither the Romanian standard
+  nor the legacy QWERTZ-ro;
+- their QWERTY-nl is just a QWERTY-intl with a € sign;
+
+Reference: [keyshorts.com] (we couldn’t find any official source…)
+
+### Linux
+
+Linux keyboard drivers follow rather closely their Windows counterpart, but
+there might be differences concerning dead keys or AltGr symbols.
+
+Besides, for a single layout there may be dozens of variants, which usually
+respect the Windows layout for printed keys but have additional dead keys or
+AltGr symbols. This is neat for users, but those variants are not handled yet
+by Ækeynox.
+
+Reference: [xkeyboard-config]
+
+[kbdlayout.info]:   https://kbdlayout.info/
+[keyshorts.com]:    https://keyshorts.com/blogs/blog/37615873-how-to-identify-macbook-keyboard-localization
+[xkeyboard-config]: https://xkeyboard-config.freedesktop.org/

--- a/include/aekeynox/emulations/README.md
+++ b/include/aekeynox/emulations/README.md
@@ -1,0 +1,61 @@
+Layout Emulation
+====================================================================================================
+
+Using a non-QWERTY layout can be done in two ways:
+
+- either by setting the host computer to use this layout, in which case `KB_LAYOUT_*` is enough
+  (see above);
+- or by letting the keyboard *emulate* a keyboard layout for a host using a default layout
+  — and that’s what `KB_EMULATION_*` is about.
+
+
+ASCII Layouts
+----------------------------------------------------------------------------------------------------
+
+Keyboard layouts that are optimized for English are usually just a rearrangement of QWERTY keys:
+Dvorak, Colemak, Workman, Sturdy… all these layouts can be perfectly emulated by the keyboard.
+
+To emulate Dvorak for QWERTY hosts, just uncomment this line in `include/aekeynox/settings.h`:
+
+```c
+#define KB_EMULATION_DVORAK
+```
+
+
+Non-ASCII Layouts
+----------------------------------------------------------------------------------------------------
+
+Emulating layouts designed for other languages is trickier.
+
+First, a keyboard layout with extended characters is required on the host computer.
+That’s our emulation target.
+
+- [QWERTY-intl] is a sane default for west-European languages. It’s available on every computer,
+  it just has to be enabled.
+- Local layouts (AZERTY, QWERTZ, non-US QWERTY variants…) are good emulation targets as well.
+  Not as versatile as QWERTY-intl, but they’re the local default.
+
+As an example, to emulate Ergol for AZERTY hosts, uncomment these two lines:
+
+```c
+#define KB_LAYOUT_AZERTY
+#define KB_EMULATION_ERGOL
+```
+
+Now, here’s the tricky part:
+these non-US layouts are likely to differ significantly across Windows, macOS, Linux.
+QWERTY-intl is probably the most consistent one, but it still comes with minor differences.
+
+By default, Ækeynox assumes the lowest common character subset, which is provided by Windows layouts.
+This ensures your keeb will work consistently across all major platforms. But unless you need your
+keyboard to be usable with *any* OS, you’ll have a better experience by activating OS-specific options:
+
+- either by selecting the `MACOS` or `LINUX` option, if that’s the targeted host OS;
+- or by selecting the `ENABLE_CP1252_ALT_CODES` option, which leverages Windows’ [Alt-Codes].
+
+The emulation of non-ASCII layouts is being actively developed.
+It’s already used as a daily driver by some of our European contributors.
+Feedback and patches are very welcome.
+
+[QWERTY-intl]: https://commons.wikimedia.org/wiki/File:KB_US-International.svg
+[Alt-Codes]:   https://altcodeunicode.com/

--- a/include/aekeynox/extra_layers/README.md
+++ b/include/aekeynox/extra_layers/README.md
@@ -23,12 +23,11 @@ When possible, it’s placed on the `SEMI` key (QWERTY’s <kbd>;:</kbd> key).
 - [Layout-Specific Adaptations](#layout-specific-adaptations)
   - [AZERTY-1dk](#azerty-1dk-french)
   - [Bépolar](#bépolar-french)
+  - [Programmers’ QWERTY](#programmers-qwerty)
   - [Other Layouts](#other-layouts)
-- [Programmer’s QWERTY](#programmers-qwerty)
 - [Six-Column Configurations](#six-column-configurations)
   - [QWERTY-intl](#qwerty-intl)
   - [Non-ASCII Layouts](#non-ascii-layouts)
-- [Resources](#resources)
 
 
 Multilingual Adaptations
@@ -206,7 +205,7 @@ AZERTY-1dk replaces the <kbd>ù</kbd> key with <kbd>1dk</kbd>, on the 6th column
     |---------------|---------------|
 ```
 
-For a better alternative, see <https://qwerty-lafayette.org>.
+For a better alternative, see [QWERTY-Lafayette](https://qwerty-lafayette.org).
 It can be emulated by Ækeynox on any AZERTY or QWERTY-intl host.
 
 ### Bépolar (French)
@@ -235,23 +234,19 @@ that’s been designed *specifically* for ergonomic keyboards.
     |---------------|---------------|
 ```
 
-For a better alternative, see <https://ergol.org>.
+For a better alternative, see [Ergo‑L](https://ergol.org).
 It can be emulated by Ækeynox on any AZERTY or QWERTY-intl host.
 
-### Other Layouts
-
-Many other national layouts are still missing: Croatian, Hungarian, Turkish…
-
-If you use one of these layouts, please open a ticket and we’ll work something
-out.
-
-
-Programmer’s QWERTY
---------------------------------------------------------------------------------
+### Programmers’ QWERTY
 
 Many European languages in central or eastern Europe have a “Programmers’ QWERTY”
 variant, with a QWERTY-ANSI base layer and special chars in an secondary layer
 (often AltGr). This seems to be a natural fit for ergonomic keyboards.
+
+- [ ] QWERTY-cz: Czech Republic
+- [ ] QWERTY-hu: Hungary (101-key)
+- [ ] QWERTY-pl: Poland
+- [ ] QWERTY-ro: Romania
 
 However:
 
@@ -260,6 +255,22 @@ However:
 
 If you use such a layout, please open a ticket and we’ll propose a dedicated
 adaptation.
+
+### Other Layouts
+
+Many other national layouts are still missing, among which:
+
+- [ ] QWERTY-ca: Canada (Multilingual)
+- [ ] QWERTY-hr: Bosnia, Croatia, Serbia (+ Slovenia, almost identical)
+- [ ] QWERTY-pl: Poland (214)
+- [ ] QWERTY-tr: Turkey
+
+- [ ] QWERTZ-cz: Czech Republic
+- [ ] QWERTZ-hu: Hungary
+- [ ] QWERTZ-sk: Slovakia
+
+If you use one of these layouts, please open a ticket and we’ll work something
+out.
 
 
 Six-Column Configurations
@@ -308,10 +319,3 @@ customized to include it under the left pinky.
 
 We still (highly) recommend using a `1dk` layer instead (both `Nordic` and
 `Transalp` work fine with German); but *your keyboard, your rules!*
-
-
-Resources
---------------------------------------------------------------------------------
-
-- [kbdlayout.info](https://kbdlayout.info/) for Windows
-- [keyshorts.com](https://keyshorts.com/blogs/blog/37615873-how-to-identify-macbook-keyboard-localization#german) for macOS


### PR DESCRIPTION
This splits the layout in four parts:

- `include/aekeynox/READE.md` is the keymap configuration guide, with three subsections:
  - `aliases/READE.md`: host keyboard layouts
  - `emulations/READE.md`: onboard layout emulations
  - `extra_layers/READE.md`: onboard layout adaptations
- the main README becomes a quick intro with links to the sections above.