### PR TITLE
feat: KB_EXTRA_LAYERS_*

### DIFF
--- a/include/aekeynox/aliases/qwerty_br.h
+++ b/include/aekeynox/aliases/qwerty_br.h
@@ -1,6 +1,10 @@
 // Brazil (ABNT2)
 // https://kbdlayout.info/00010416/
 
+#ifdef KB_EXTRA_LAYERS_AUTO
+  #define KB_EXTRA_LAYERS_TRANSAT
+#endif
+
 /**
  * Action Combos
  */

--- a/include/aekeynox/aliases/qwerty_es.h
+++ b/include/aekeynox/aliases/qwerty_es.h
@@ -1,6 +1,10 @@
 // Spain
 // https://kbdlayout.info/0000040a/
 
+#ifdef KB_EXTRA_LAYERS_AUTO
+  #define KB_EXTRA_LAYERS_TRANSAT
+#endif
+
 /**
  * Dead Keys
  */

--- a/include/aekeynox/aliases/qwerty_latam.h
+++ b/include/aekeynox/aliases/qwerty_latam.h
@@ -1,6 +1,10 @@
 // Latin America
 // https://kbdlayout.info/0000080a/
 
+#ifdef KB_EXTRA_LAYERS_AUTO
+  #define KB_EXTRA_LAYERS_TRANSAT
+#endif
+
 /**
  * Dead Keys
  */

--- a/include/aekeynox/aliases/qwerty_pt.h
+++ b/include/aekeynox/aliases/qwerty_pt.h
@@ -1,6 +1,10 @@
 // Portugal
 // https://kbdlayout.info/00000816/
 
+#ifdef KB_EXTRA_LAYERS_AUTO
+  #define KB_EXTRA_LAYERS_TRANSAT
+#endif
+
 /**
  * Action Combos
  */

--- a/include/aekeynox/aliases/qwertz_ch.h
+++ b/include/aekeynox/aliases/qwertz_ch.h
@@ -1,6 +1,10 @@
 // Switzerland
 // https://kbdlayout.info/00000807/
 
+#ifdef KB_EXTRA_LAYERS_AUTO
+  #define KB_EXTRA_LAYERS_TRANSALP
+#endif
+
 /**
  * Action Combos
  */

--- a/include/aekeynox/aliases/qwertz_de.h
+++ b/include/aekeynox/aliases/qwertz_de.h
@@ -1,6 +1,10 @@
 // Germany, Austria
 // https://kbdlayout.info/00000407/
 
+#ifdef KB_EXTRA_LAYERS_AUTO
+  #define KB_EXTRA_LAYERS_TRANSALP
+#endif
+
 /**
  * Action Combos
  */

--- a/include/aekeynox/defaults.h
+++ b/include/aekeynox/defaults.h
@@ -41,3 +41,21 @@
 #else
   #define OMIT_IF_NO_REF
 #endif
+
+// Extra Layers
+
+#if !defined KB_EXTRA_LAYERS_TRANSALP \
+  && !defined KB_EXTRA_LAYERS_TRANSAT \
+  && !defined KB_EXTRA_LAYERS_NONE    \
+  && !defined KB_EXTRA_LAYERS_AUTO    \
+  // use the default extra layers if needed
+  #define KB_EXTRA_LAYERS_AUTO
+#endif
+
+// Outer Keys
+
+#if defined KB_EXTRA_LAYERS_NONE || \
+  (defined KB_EXTRA_LAYERS_AUTO && defined KB_LAYOUT_QWERTY_INTL)
+  // enable outer alpha keys if needed
+  #define USE_ALPHA_ON_OUTER_KEYS
+#endif

--- a/include/aekeynox/extra_layers/README.md
+++ b/include/aekeynox/extra_layers/README.md
@@ -27,7 +27,7 @@ When possible, it’s placed on the `SEMI` key (QWERTY’s <kbd>;:</kbd> key).
 - [Programmer’s QWERTY](#programmers-qwerty)
 - [Six-Column Configurations](#six-column-configurations)
   - [QWERTY-intl](#qwerty-intl)
-  - [Non-US QWERTY and QWERTZ](#non-us-qwerty-and-qwertz)
+  - [Non-ASCII Layouts](#non-ascii-layouts)
 - [Resources](#resources)
 
 
@@ -35,17 +35,30 @@ Multilingual Adaptations
 --------------------------------------------------------------------------------
 
 Most West-European languages can be supported by three 1dk layers: Nordic,
-Transalp, Transat. They can be used either on QWERTY or QWERTZ.
+Transalp, Transat. They can be used either on QWERTY or QWERTZ, they’re
+activated by default on relevant non-ASCII layouts, and they can be explicitly
+selected with one of the following definitions:
+
+- [ ] `KB_EXTRA_LAYERS_NORDIC`
+- [x] `KB_EXTRA_LAYERS_TRANSALP`
+- [x] `KB_EXTRA_LAYERS_TRANSAT`
+- [x] `KB_EXTRA_LAYERS_NONE`
 
 ### Nordic
 
-Recommended layouts:
+Activated by default on:
 
 - [ ] QWERTY-dk: Denmark
 - [ ] QWERTY-is: Iceland
 - [ ] QWERTY-no: Norway
 - [ ] QWERTY-se: Sweden, Finland, Estonia (?)
 - [ ] QWERTZ-de: Germany, Austria
+
+Suitable for:
+
+- [ ] QWERTY-intl
+- [ ] QWERTY-nl: Dutch
+- [ ] QWERTZ-de: German
 
 ```
     |---------------|---------------|  base
@@ -74,20 +87,25 @@ Supported languages:
 - [ ] Faroese:                     `å`, `æ`, `ø`, `ð`
 - [ ] Icelandic:                   `þ`, `æ`, `ö`, `ð`, `áéíóúý` (+ diaeresis?)
 
-This might be suitable for [Dutch](https://en.wikipedia.org/wiki/Dutch_orthography) as well:
+This is suitable for [Dutch] as well if `^` and `˝` are ignored:
 
 > Dutch uses the acute accent to mark stress and the diaeresis (trema) to
 > disambiguate diphthongs/triphthongs. Occasionally, other diacritics are used
-> in loanwords and native onomatopoeic words (e.g. circumflex and grave accent
-> for French loanwords).
+> in loanwords and native onomatopoeic words.
+
+[Dutch]: https://en.wikipedia.org/wiki/Dutch_orthography
 
 ### Transalp
 
-Recommended layouts:
+Activated by default on:
 
 - [x] QWERTZ-ch: Switzerland, Luxembourg, Liechtenstein
 - [x] QWERTZ-de: Germany, Austria
 - [ ] QWERTY-it: Italy
+
+Suitable for:
+
+- [x] QWERTY-intl
 
 ```
     |---------------|---------------|  base
@@ -117,12 +135,16 @@ Supported languages:
 
 ### Transat
 
-Recommended layouts:
+Activated by default on:
 
 - [x] QWERTY-br: Brazil
 - [x] QWERTY-latam: Latin America
 - [x] QWERTY-es: Spain
 - [x] QWERTY-pt: Portugal
+
+Suitable for:
+
+- [x] QWERTY-intl
 
 ```
     |---------------|---------------|  base
@@ -227,7 +249,7 @@ out.
 Programmer’s QWERTY
 --------------------------------------------------------------------------------
 
-Many European languages in central or eastern Europe have a “Programmer’s QWERTY”
+Many European languages in central or eastern Europe have a “Programmers’ QWERTY”
 variant, with a QWERTY-ANSI base layer and special chars in an secondary layer
 (often AltGr). This seems to be a natural fit for ergonomic keyboards.
 
@@ -243,14 +265,15 @@ adaptation.
 Six-Column Configurations
 --------------------------------------------------------------------------------
 
-The `USE_ALPHA_ON_OUTER_KEYS` option opens up another way to fit non-ASCII
-layouts on an ergonomic keyboard.
+On 3×6 keyboards, you could use four extra alpha keys on outer columns to fit
+some non-ASCII layouts.
+
 
 ### QWERTY-intl
 
-When using QWERTY-intl, you *want* to enable `USE_ALPHA_ON_OUTER_KEYS` to have a
-direct access to dead diacritics on the outer columns.
-Here’s the default configuration:
+When using QWERTY-intl without selecting a 1dk layer explicitly, these four
+extra keys are enabled to provide a direct access to dead diacritics on outer
+columns. Here’s the default configuration:
 
 ```
     |---------------|---------------|
@@ -263,12 +286,13 @@ Here’s the default configuration:
 Depending on your main language, you might want to adjust the position of these
 four extra keys in the `/include/aekeynox/outer_keys.h` file.
 
-### Non-US QWERTY and QWERTZ
+### Non-ASCII Layouts
 
-For other QWERTY and QWERTZ variants, the 6th column is kept on the right, while
-the 7th column is moved to the left.
+For AZERTY and other QWERTY and QWERTZ variants, you can force the use of these
+outer columns with the `KB_EXTRA_LAYERS_NONE` option: the 6th column is kept on
+the right, while the 7th column is moved to the left.
 
-As an example, QWERTZ-de works okay with `USE_ALPHA_ON_OUTER_KEYS`:
+As an example, QWERTZ-de works okay with `KB_EXTRA_LAYERS_NONE`:
 
 ```
     |---------------|---------------|

--- a/include/aekeynox/extra_layers/transalp.dtsi
+++ b/include/aekeynox/extra_layers/transalp.dtsi
@@ -1,5 +1,3 @@
-#ifndef USE_ALPHA_ON_OUTER_KEYS
-
 #include "1dk.dtsi"
 
 /**
@@ -64,5 +62,3 @@
 
   };
 };
-
-#endif // USE_ALPHA_ON_OUTER_KEYS

--- a/include/aekeynox/extra_layers/transat.dtsi
+++ b/include/aekeynox/extra_layers/transat.dtsi
@@ -1,5 +1,3 @@
-#ifndef USE_ALPHA_ON_OUTER_KEYS
-
 #include "1dk.dtsi"
 
 /**
@@ -96,5 +94,3 @@
 
   };
 };
-
-#endif // USE_ALPHA_ON_OUTER_KEYS

--- a/include/aekeynox/selenium.keymap
+++ b/include/aekeynox/selenium.keymap
@@ -152,14 +152,16 @@
   #include "emulations/qwerty_lafayette.dtsi"
 
 // Some layouts require extra layers to fit on a 3×10 grid
-#elif defined KB_LAYOUT_AZERTY
-  #include "extra_layers/azerty_1dk.dtsi"
-#elif defined KB_LAYOUT_BEPO
-  #include "extra_layers/bepolar.dtsi"
-#elif defined KB_LAYOUT_QWERTY_BR || defined KB_LAYOUT_QWERTY_ES || defined KB_LAYOUT_QWERTY_LATAM || defined KB_LAYOUT_QWERTY_PT
-  #include "extra_layers/transat.dtsi"
-#elif defined KB_LAYOUT_QWERTZ_DE || defined KB_LAYOUT_QWERTZ_CH_DE || defined KB_LAYOUT_QWERTZ_CH_FR
-  #include "extra_layers/transalp.dtsi"
+#elif !defined KB_EXTRA_LAYERS_NONE
+  #if defined KB_LAYOUT_AZERTY
+    #include "extra_layers/azerty_1dk.dtsi"
+  #elif defined KB_LAYOUT_BEPO
+    #include "extra_layers/bepolar.dtsi"
+  #elif defined KB_EXTRA_LAYERS_TRANSALP
+    #include "extra_layers/transalp.dtsi" // default for CH, DE, IT
+  #elif defined KB_EXTRA_LAYERS_TRANSAT
+    #include "extra_layers/transat.dtsi"  // default for BR, ES, LATAM, PT
+  #endif
 
 // Experimental ergol variant meant for Hummingbird-style keyboards
 #elif defined KB_LAYOUT_ERGOL && defined HUMMINGBIRD

--- a/include/aekeynox/settings.h
+++ b/include/aekeynox/settings.h
@@ -32,13 +32,24 @@
 // #define MACOS
 // #define LINUX
 
-// By default, Ækeynox fits all layouts on a 3×10 grid, using a dead key (1dk)
-// for extra chars if necessary, and keeps the 6th columns for non-alpha keys:
-// Tab, Escape, Backspace, Enter.
-// Uncomment the following line to use these 6th columns for alpha keys instead.
-// Warning: this also disables all 1dk layers.
 
-// #define USE_ALPHA_ON_OUTER_KEYS
+/******************************************************************************
+ * Extra Layers
+******************************************************************************/
+
+// By default, Ækeynox fits all non-ASCII layouts on a 3×10 grid by:
+//  - replacing the the semicolon key by a one-shot layer key (1dk)
+//  - adding two layers, 1dk and 1dkShift, containing all non-ASCII characters
+// These 1dk layers are defined by default to best match the requested layout,
+// but you can override them by uncommenting one of the lines below, e.g. to
+// use them along with QWERTY-intl.
+// Alternatively, you may uncomment the last line to use the outer columns
+// for 4 extra alpha keys instead of the default Tab, Escape, Backspace, Enter.
+
+// #define KB_EXTRA_LAYERS_AUTO      // default (recommended)
+// #define KB_EXTRA_LAYERS_TRANSALP  // default for CH, DE, IT
+// #define KB_EXTRA_LAYERS_TRANSAT   // default for BR, ES, LATAM, PT
+// #define KB_EXTRA_LAYERS_NONE      // disable all 1dk layers, use outer cols
 
 
 /******************************************************************************

--- a/tests.yaml
+++ b/tests.yaml
@@ -57,7 +57,7 @@ include:
     # QWERTY-intl (US-International)
   - board: quacken_flex/rp2040
     artifact-name: qwerty_intl
-    cmake-args: -DDTS_EXTRA_CPPFLAGS="-DCI_IGNORE_USER_SETTINGS;-DKB_LAYOUT_QWERTY_INTL;-DUSE_ALPHA_ON_OUTER_KEYS"
+    cmake-args: -DDTS_EXTRA_CPPFLAGS="-DCI_IGNORE_USER_SETTINGS;-DKB_LAYOUT_QWERTY_INTL"
 
     # QWERTY-latam (Latin America)
   - board: quacken_flex/rp2040


### PR DESCRIPTION
- add a preference to pick non-default extra layers, e.g.:
  - to use `nordic.dtsi` instead of `transalp.dtsi` for DE (Germany)
  - to use along with QWERTY-intl layout so it fits on a 3*10 grid
- auto-select `USE_ALPHA_ON_OUTER_KEYS` for pure QWERTY-intl usage
- disable `bepo.dtsi` when `USE_ALPHA_ON_OUTER_KEYS` is defined