### PR TITLE
perf: don’t run the main CI both on PRs and pushes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,5 @@
 name: Build ZMK firmware
-on: [push, pull_request, workflow_dispatch]
+on: [push, workflow_dispatch]
 
 jobs:
   build:


### PR DESCRIPTION
Pushing commits in a PR often causes the CI to be run twice, which is needlessly slow.