### PR TITLE
feat: QWERTY-ee (Estonia) + Nordic

### DIFF
--- a/include/aekeynox/aliases.h
+++ b/include/aekeynox/aliases.h
@@ -38,6 +38,8 @@
   #include "aliases/qwerty_br.h"
 #elifdef KB_LAYOUT_QWERTY_DK
   #include "aliases/qwerty_dk.h"
+#elifdef KB_LAYOUT_QWERTY_EE
+  #include "aliases/qwerty_ee.h"
 #elifdef KB_LAYOUT_QWERTY_ES
   #include "aliases/qwerty_es.h"
 #elifdef KB_LAYOUT_QWERTY_IT

--- a/include/aekeynox/aliases/README.md
+++ b/include/aekeynox/aliases/README.md
@@ -36,6 +36,7 @@ others:
 | 💡 | `KB_LAYOUT_QWERTY_CA`    | Canada                            | Multilingual
 | 💡 | `KB_LAYOUT_QWERTY_CZ`    | Czech Republic                    | Programmers
 | ✅ | [`KB_LAYOUT_QWERTY_DK`]    | Denmark                           |
+| ✅ | [`KB_LAYOUT_QWERTY_EE`]    | Estonia                           |
 | ✅ | [`KB_LAYOUT_QWERTY_ES`]    | Spain                             |
 | 💡 | `KB_LAYOUT_QWERTY_HR`    | Bosnia, Croatia, Serbia, Slovenia |
 | 💡 | `KB_LAYOUT_QWERTY_HU`    | Hungary                           | 101-key
@@ -72,6 +73,7 @@ ones:
 [`KB_LAYOUT_QWERTY`]:       https://kbdlayout.info/kbdus
 [`KB_LAYOUT_QWERTY_BR`]:    https://kbdlayout.info/kbdbr
 [`KB_LAYOUT_QWERTY_DK`]:    https://kbdlayout.info/kbdda
+[`KB_LAYOUT_QWERTY_EE`]:    https://kbdlayout.info/kbdest
 [`KB_LAYOUT_QWERTY_ES`]:    https://kbdlayout.info/kbdsp
 [`KB_LAYOUT_QWERTY_INTL`]:  https://kbdlayout.info/kbdusx
 [`KB_LAYOUT_QWERTY_IT`]:    https://kbdlayout.info/kbdit142

--- a/include/aekeynox/aliases/dead_keys.h
+++ b/include/aekeynox/aliases/dead_keys.h
@@ -475,3 +475,30 @@
 #ifndef SC_ZCAR
 #define SC_ZCAR DI_CAR RS(Z)
 #endif
+
+/**
+ * Ring Above
+ */
+
+#if (defined DEAD_ABOVE_RING) && DEAD_ABOVE_RING
+  #define DI_RNG &digraph DEAD_ABOVE_RING
+  #define DK_RNG &kp DEAD_ABOVE_RING
+#else
+  #define DI_RNG &kp
+  #define DK_RNG &none
+  #ifdef ENABLE_CP1252_ALT_CODES
+    #ifndef  C_ARNG
+    #define  C_ARNG CP1252_LOWERCASE_A_RING
+    #endif
+    #ifndef SC_ARNG
+    #define SC_ARNG CP1252_UPPERCASE_A_RING
+    #endif
+  #endif
+#endif
+
+#ifndef  C_ARNG
+#define  C_ARNG DI_RNG A
+#endif
+#ifndef SC_ARNG
+#define SC_ARNG DI_RNG RS(A)
+#endif

--- a/include/aekeynox/aliases/qwerty_dk.h
+++ b/include/aekeynox/aliases/qwerty_dk.h
@@ -29,6 +29,13 @@
 #define DEAD_CIRCUMFLEX RBRC
 #define DEAD_TILDE      RA(RBKT)
 
+#define  C_AE   &kp SEMI  // æ
+#define SC_AE   &kp COLON // Æ
+#define  C_OSTR &kp SQT   // ø
+#define SC_OSTR &kp DQT   // Ø
+#define  C_ARNG &kp LBKT  // å
+#define SC_ARNG &kp LBRC  // Å
+
 #include "dead_keys.h"
 
 /**
@@ -97,12 +104,6 @@
   #define SC_ETH  &kp LS(D)
   #define  C_SZ   &digraph S S
 #endif
-#define  C_AE   &kp SEMI  // æ
-#define SC_AE   &kp COLON // Æ
-#define  C_OSTR &kp SQT   // ø
-#define SC_OSTR &kp DQT   // Ø
-#define  C_ARNG &kp LBKT  // å
-#define SC_ARNG &kp LBRC  // Å
 
 // Other symbols
 #ifdef ENABLE_CP1252_ALT_CODES

--- a/include/aekeynox/aliases/qwerty_ee.h
+++ b/include/aekeynox/aliases/qwerty_ee.h
@@ -1,5 +1,5 @@
-// Sweden
-// https://kbdlayout.info/kbdse
+// Estonia
+// https://kbdlayout.info/kbdest
 
 #ifdef KB_EXTRA_LAYERS_AUTO
   #define KB_EXTRA_LAYERS_NORDIC
@@ -23,18 +23,35 @@
  * Diacritics
  */
 
-#define DEAD_ACUTE      EQUAL
-#define DEAD_GRAVE      PLUS
-#define DEAD_DIAERESIS  RBKT
-#define DEAD_CIRCUMFLEX RBRC
-#define DEAD_TILDE      RA(RBKT)
+#define DEAD_ACUTE EQUAL
+#define DEAD_GRAVE PLUS
+#define DEAD_CARON GRAVE
+#define DEAD_TILDE TILDE
 
-#define  C_ARNG &kp LBKT  // å
-#define SC_ARNG &kp LBRC  // Å
+#define SA(key) RS(RA(key))
+
+#ifdef LINUX
+  #define S_CARET     &kp RA(SQT)
+  #define DEAD_CIRCUMFLEX SA(SQT)
+  #define DEAD_DIAERESIS  RA(LBKT)
+  #define DEAD_ABOVE_RING SA(LBKT)
+#else
+  #define S_CARET     &kp SA(SQT)
+  #define DEAD_CIRCUMFLEX RA(SQT)
+#endif
+
 #define  C_ADIA &kp SQT   // ä
 #define SC_ADIA &kp DQT   // Ä
 #define  C_ODIA &kp SEMI  // ö
 #define SC_ODIA &kp COLON // Ö
+#define  C_UDIA &kp LBKT  // ü
+#define SC_UDIA &kp LBRC  // Ü
+#define  C_OTLD &kp RBKT  // õ
+#define SC_OTLD &kp RBRC  // Õ
+#define  C_SCAR &kp RA(S) // č
+#define SC_SCAR &kp SA(S) // Č
+#define  C_ZCAR &kp RA(Z) // ž
+#define SC_ZCAR &kp SA(Z) // Ž
 
 #include "dead_keys.h"
 
@@ -46,7 +63,7 @@
  */
 
 // first row
-#define S_CARET DI_CIR SPACE
+// XXX: S_CARET is OS-specific
 #define S_LT    &kp NUBS
 #define S_GT    &kp PIPE2
 #define S_DLLR  &kp RA(N4)
@@ -100,7 +117,6 @@
   #define SC_THRN CP1252_UPPERCASE_THORN    // Þ
   #define  C_ETH  CP1252_LOWERCASE_ETH      // ð
   #define SC_ETH  CP1252_UPPERCASE_ETH      // Ð
-  #define  C_SZ   CP1252_LOWERCASE_SZ       // ß
 #else
   #define  C_AE    C_ADIA
   #define SC_AE   SC_ADIA
@@ -110,18 +126,33 @@
   #define SC_THRN &kp LS(T)
   #define  C_ETH  &kp    D
   #define SC_ETH  &kp LS(D)
-  #define  C_SZ   &digraph S S
+#endif
+
+// ß, «»
+#ifdef LINUX
+  #define C_SZ   &kp RA(W)  // ß
+  #define C_LGQT &kp SA(X)  // «
+  #define C_RGQT &kp RA(X)  // »
+#elifdef ENABLE_CP1252_ALT_CODES
+  #define C_SZ   CP1252_LOWERCASE_SZ    // ß
+  #define C_LGQT CP1252_LEFT_GUILLEMET  // «
+  #define C_RGQT CP1252_RIGHT_GUILLEMET // »
+#else
+  #define C_SZ   &digraph S S
+  #define C_LGQT &kp S_DQT
+  #define C_RGQT &kp S_DQT
 #endif
 
 // Other symbols
 #ifdef ENABLE_CP1252_ALT_CODES
-  #define C_CENT  CP1252_CENT    // ¢
-  #define C_DEG   CP1252_DEGREE  // °
+  #define C_CENT  CP1252_CENT   // ¢
+  #define C_DEG   CP1252_DEGREE // °
+  #define C_MICRO CP1252_MICRO  // µ
 #else
   #define C_CENT  &none
   #define C_DEG   &none
+  #define C_MICRO &none
 #endif
-#define C_EURO  &kp RA(E)  // €
-#define C_POUND &kp RA(N3) // £
-#define C_SILC  &kp GRAVE  // §
-#define C_MICRO &kp RA(M)  // µ
+#define C_EURO  &kp RA(E)    // €
+#define C_POUND &kp RA(N3)   // £
+#define C_SILC  &kp RA(RBKT) // §

--- a/include/aekeynox/extra_layers/README.md
+++ b/include/aekeynox/extra_layers/README.md
@@ -17,7 +17,7 @@ to represent it.
 When possible, it’s placed on the `SEMI` key (QWERTY’s <kbd>;:</kbd> key).
 
 - [Multilingual Adaptations](#multilingual-adaptations)
-  - [Nordic](#nordic-todo) (Danish, Faroese, Finnish, Icelandic, Norwegian, Swedish)
+  - [Nordic](#nordic-todo) (Danish, Estonian, Faroese, Finnish, Icelandic, Norwegian, Swedish)
   - [Transalp](#transalp) (French, German, Italian)
   - [Transat](#transat-todo) (Portuguese, Spanish, Aranese, Basque, Catalan, Galician)
 - [Layout-Specific Adaptations](#layout-specific-adaptations)
@@ -47,6 +47,7 @@ selected with one of the following definitions:
 Activated by default on:
 
 - [x] [QWERTY-dk]: Denmark
+- [x] [QWERTY-ee]: Estonia
 - [ ] [QWERTY-is]: Iceland
 - [x] [QWERTY-no]: Norway
 - [x] [QWERTY-se]: Sweden, Finland
@@ -54,6 +55,7 @@ Activated by default on:
 Suitable for:
 
 - [x] [QWERTY-intl]
+- [ ] [QWERTY-nl]: Netherlands (but `^` and `˝` are missing)
 - [x] [QWERTZ-de]: Germany, Austria
 
 ```
@@ -64,15 +66,15 @@ Suitable for:
     |---------------|---------------|
 
     |---------------|---------------|  1dk
-    |    ä æ € £ þ  |    ü   ö      |
-    |    å ß ð ( )  |        ø ´    |
-    |      §   ? !  |    µ          |
+    |    å æ € £ þ  |    ü õ ö      |
+    |    ä š ð ( )  |        ø ´    |
+    |    ž ß § ? !  |    µ          |
     |---------------|---------------|
 
     |---------------|---------------|  1dkShift
-    |    Ä Æ     Þ  |    Ü   Ö      |
-    |    Å   Ð      |        Ø      |
-    |               |               |
+    |    Å Æ     Þ  |    Ü Õ Ö      |
+    |    Ä Š Ð      |        Ø      |
+    |    Ž          |               |
     |---------------|---------------|
 ```
 
@@ -80,17 +82,10 @@ Supported languages:
 
 - [x] Swedish, Finnish:  `å`, `ä`, `ö`
 - [x] Danish, Norwegian: `å`, `æ`, `ø`
+- [x] Estonian:          `õ`, `äöü`, `šž`
 - [x] Faroese:           `å`, `æ`, `ø`, `ð`
 - [x] German:            `ß`, `äöü`
 - [x] Icelandic:         `þ`, `æ`, `ö`, `ð`, `áéíóúý`
-
-This is suitable for [Dutch] as well if `^` and `˝` are ignored:
-
-> Dutch uses the acute accent to mark stress and the diaeresis (trema) to
-> disambiguate diphthongs/triphthongs. Occasionally, other diacritics are used
-> in loanwords and native onomatopoeic words.
-
-[Dutch]: https://en.wikipedia.org/wiki/Dutch_orthography
 
 ### Transalp
 
@@ -323,6 +318,7 @@ We still (highly) recommend using a `1dk` layer instead (both `Nordic` and
 [QWERTY]:       https://kbdlayout.info/kbdus
 [QWERTY-br]:    https://kbdlayout.info/kbdbr
 [QWERTY-dk]:    https://kbdlayout.info/kbdda
+[QWERTY-ee]:    https://kbdlayout.info/kbdest
 [QWERTY-es]:    https://kbdlayout.info/kbdsp
 [QWERTY-intl]:  https://kbdlayout.info/kbdusx
 [QWERTY-is]:    https://kbdlayout.info/kbdic
@@ -330,6 +326,7 @@ We still (highly) recommend using a `1dk` layer instead (both `Nordic` and
 [QWERTY-latam]: https://kbdlayout.info/kbdla
 [QWERTY-no]:    https://kbdlayout.info/kbdno
 [QWERTY-no]:    https://kbdlayout.info/kbdsp
+[QWERTY-nl]:    https://kbdlayout.info/kbdne
 [QWERTY-no]:    https://kbdlayout.info/kbdus
 [QWERTY-pt]:    https://kbdlayout.info/kbdpo
 [QWERTY-se]:    https://kbdlayout.info/kbdse

--- a/include/aekeynox/extra_layers/nordic.dtsi
+++ b/include/aekeynox/extra_layers/nordic.dtsi
@@ -1,10 +1,11 @@
 #include "1dk.dtsi"
 
 /**
- * This adds a dead key (1dk) to access all common Scandinavian chars.
+ * This adds a dead key (1dk) to access all common Scandinavian and Finnic chars.
  *
  * Activated by default on:
  *  - QWERTY-dk, used in Denmark
+ *  - QWERTY-ee, used in Estonia
  *  - QWERTY-no, used in Norway
  *  - QWERTY-se, used in Sweden and Finland
  *
@@ -15,7 +16,9 @@
  * Language-specific chars:
  *  - Swedish, Finnish:  `å`, `ä`, `ö`
  *  - Danish, Norwegian: `å`, `æ`, `ø`
+ *  - Estonian:          `õ`, `äöü`, `šž`
  *  - Faroese(?):        `å`, `æ`, `ø`, `ð` (?)
+ *  - German:            `ß`, `äöü`
  *  - Icelandic(?):      `þ`, `æ`, `ö`, `ð`, `áéíóúý` (+ diaeresis?)
  *
  * These Danish-like layouts would be nice to have:
@@ -23,10 +26,15 @@
  *  - QWERTY-??: Greenland (is there any Kalaallisut support on Linux?)
  *  - QWERTY-is: Iceland
  *
- * These Finno-Samic layouts would be nice to have as well:
- *  - QWERTY-ee: Estonia
+ * Samic layouts would be nice to have as well:
  *  - QWERTY-no-sami: Norway + Sami extenstions
  *  - QWERTY-se-sami: Sweden + Sami extenstions
+ *
+ * This is suitable for [Dutch] as well if `^` and `˝` are ignored:
+ * > Dutch uses the acute accent to mark stress and the diaeresis (trema) to
+ * > disambiguate diphthongs/triphthongs. Occasionally, other diacritics are
+ * > used in loanwords and native onomatopoeic words.
+ * https://en.wikipedia.org/wiki/Dutch_orthography
 **/
 
 / {
@@ -34,33 +42,33 @@
     compatible = "zmk,keymap";
 
     //  |---------------|---------------|
-    //  |    ä æ € £ þ  |    ü   ö      |
-    //  |    å ß ð ( )  |        ø ´    |
-    //  |      §   ? !  |    µ          |
+    //  |    å æ € £ þ  |    ü õ ö      |
+    //  |    ä š ð ( )  |        ø ´    |
+    //  |    ž ß § ? !  |    µ          |
     //  |---------------|---------------|
 
     one_dead_key {
       display-name = "1dk";
       bindings = <SELENIUM_KEYMAP_BINDINGS(
-        &trans  ,  C_ADIA  C_AE    C_EURO  C_POUND C_THRN   ,   &trans  C_UDIA  &trans  C_ODIA  &trans  ,  &trans ,
-        &trans  ,  C_ARNG  C_SZ    C_ETH   S_LPAR  S_RPAR   ,   &trans  &trans  &trans  C_OSTR  DK_ACU  ,  &trans ,
-        K_ODKS  ,  &trans  C_SILC  &trans  S_QMARK S_EXCL   ,   &trans  C_MICRO &trans  &trans  &trans  ,  K_ODKS ,
+        &trans  ,  C_ARNG  C_AE    C_EURO  C_POUND C_THRN   ,   &trans  C_UDIA  C_OTLD  C_ODIA  &trans  ,  &trans ,
+        &trans  ,  C_ADIA  C_SCAR  C_ETH   S_LPAR  S_RPAR   ,   &trans  &trans  &trans  C_OSTR  DK_ACU  ,  &trans ,
+        K_ODKS  ,  C_ZCAR  C_SZ    C_SILC  S_QMARK S_EXCL   ,   &trans  C_MICRO &trans  &trans  &trans  ,  K_ODKS ,
                                  SK_ODKS , S_SQT , &trans   ,   &trans , S_SQT , &trans
       )>;
     };
 
     //  |---------------|---------------|
-    //  |    Ä Æ     Þ  |    Ü   Ö      |
-    //  |    Å   Ð      |        Ø      |
-    //  |               |               |
+    //  |    Å Æ     Þ  |    Ü Õ Ö      |
+    //  |    Ä Š Ð      |        Ø      |
+    //  |    Ž          |               |
     //  |---------------|---------------|
 
     one_dead_key_shift {
       display-name = "1dkShift";
       bindings = <SELENIUM_KEYMAP_BINDINGS(
-        &trans  ,  SC_ADIA SC_AE   &trans  &trans  SC_THRN  ,   &trans  SC_UDIA &trans  SC_ODIA &trans  ,  &trans ,
-        &trans  ,  SC_ARNG &trans  SC_ETH  &trans  &trans   ,   &trans  &trans  &trans  SC_OSTR &trans  ,  &trans ,
-        &trans  ,  &trans  &trans  &trans  &trans  &trans   ,   &trans  &trans  &trans  &trans  &trans  ,  &trans ,
+        &trans  ,  SC_ARNG SC_AE   &trans  &trans  SC_THRN  ,   &trans  SC_UDIA SC_OTLD SC_ODIA &trans  ,  &trans ,
+        &trans  ,  SC_ADIA SC_SCAR SC_ETH  &trans  &trans   ,   &trans  &trans  &trans  SC_OSTR &trans  ,  &trans ,
+        &trans  ,  SC_ZCAR &trans  &trans  &trans  &trans   ,   &trans  &trans  &trans  &trans  &trans  ,  &trans ,
                                  &trans , &trans , &trans   ,   &trans , &trans , &trans
       )>;
     };

--- a/include/aekeynox/settings.h
+++ b/include/aekeynox/settings.h
@@ -18,6 +18,7 @@
 // #define KB_LAYOUT_ERGLACE
 // #define KB_LAYOUT_QWERTY_BR
 // #define KB_LAYOUT_QWERTY_DK
+// #define KB_LAYOUT_QWERTY_EE
 // #define KB_LAYOUT_QWERTY_ES
 // #define KB_LAYOUT_QWERTY_FI
 // #define KB_LAYOUT_QWERTY_INTL

--- a/tests.yaml
+++ b/tests.yaml
@@ -54,6 +54,11 @@ include:
     artifact-name: qwerty_dk
     cmake-args: -DDTS_EXTRA_CPPFLAGS="-DCI_IGNORE_USER_SETTINGS;-DKB_LAYOUT_QWERTY_DK"
 
+    # QWERTY-ee (Estonia)
+  - board: quacken_flex/rp2040
+    artifact-name: qwerty_ee
+    cmake-args: -DDTS_EXTRA_CPPFLAGS="-DCI_IGNORE_USER_SETTINGS;-DKB_LAYOUT_QWERTY_EE"
+
     # QWERTY-es (Spain)
   - board: quacken_flex/rp2040
     artifact-name: qwerty_es
@@ -121,7 +126,7 @@ include:
     # Ergol on AZERTY
   - board: quacken_flex/rp2040
     artifact-name: azerty_to_ergol
-    cmake-args: -DDTS_EXTRA_CPPFLAGS="-DCI_IGNORE_USER_SETTINGS;-DKB_LAYOUT_AZERTY;-DKB_EMULATION_ERGOL;-DLINUX"
+    cmake-args: -DDTS_EXTRA_CPPFLAGS="-DCI_IGNORE_USER_SETTINGS;-DKB_LAYOUT_AZERTY;-DKB_EMULATION_ERGOL"
 
     # Ergol on QWERTY-intl
   - board: quacken_flex/rp2040


### PR DESCRIPTION
I’ve had to modify the Nordic layout a bit to fit Š and Ž. The new rationale is:
- the dead key acts as a dead diaeresis on A, O, U => Ä and Ä are swapped
- the dead key acts as a dead caron on S, Z => ß is moved to [X] and § is moved to [C]
- Õ is placed on [I]