### PR TITLE
feat: basic caps-word integration

### DIFF
--- a/config/west.yml
+++ b/config/west.yml
@@ -29,7 +29,7 @@ manifest:
       # More info on the changes present can be found on the fork’s README page.
     - name: zmk
       remote: NuclearSquid
-      revision: aekeynox
+      revision: caps-word  # XXX: don’t forget to switch back to aekeynox before merging
       import: app/west.yml
 
       ###

--- a/include/aekeynox/aliases/azerty.h
+++ b/include/aekeynox/aliases/azerty.h
@@ -146,3 +146,14 @@
 #define C_MULT  OS_SELECT ( &kp X     , CP1252_MULTIPLICATION ,               , &kp SA(COMMA) ) // ×
 #define C_MICRO OS_SELECT ( &kp PIPE  ,                       , &kp RA(SEMI)  ,               ) // µ
 #define C_DEG               &kp UNDER                                                           // °
+
+/**
+* Caps-Word
+*/
+
+#define CAPS_WORD_SHIFT_LIST \
+    Q  W  E  R  T    Y  U  I  O  P \
+    A  S  D  F  G    H  J  K  L  SEMI \
+    Z  X  C  V  B    N
+
+#define CAPS_WORD_CONTINUE_LIST N1 N4 N6 N7 N8 N9 N0 SQT

--- a/include/aekeynox/aliases/bepo.h
+++ b/include/aekeynox/aliases/bepo.h
@@ -74,3 +74,14 @@
     };
   };
 };
+
+/**
+* Caps-Word
+*/
+
+#define CAPS_WORD_SHIFT_LIST \
+         Q  W  E  R  T       U    I    O   P    LBKT RBKT \
+         A  S  D  F       H  J    K    L   SEMI SQT  BSLH \
+    NUBS Z  X  C     B       M  COMMA DOT  FSLH
+
+#define CAPS_WORD_CONTINUE_LIST Y N

--- a/include/aekeynox/aliases/bepolar.h
+++ b/include/aekeynox/aliases/bepolar.h
@@ -62,3 +62,14 @@
 #define S_COMMA &kp G
 #define S_DOT   &kp V
 #define S_MONEY &kp LS(BSLH)
+
+/**
+* Caps-Word
+*/
+
+#define CAPS_WORD_SHIFT_LIST \
+    Q  W  E  R  T    Y  U  I  O  P \
+    A  S  D  F  G    H  J  K  L  SEMI \
+    Z  X  C  V  B    N  M  COMMA  DOT  FSLH
+
+#define CAPS_WORD_CONTINUE_LIST

--- a/include/aekeynox/aliases/dvorak.h
+++ b/include/aekeynox/aliases/dvorak.h
@@ -62,3 +62,14 @@
 #define S_COMMA &kp W
 #define S_DOT   &kp E
 #define S_MONEY &kp DLLR
+
+/**
+* Caps-Word
+*/
+
+#define CAPS_WORD_SHIFT_LIST \
+             R  T    Y  U  I  O  P \
+    A  S  D  F  G    H  J  K  L  SEMI \
+       X  C  V  B    N  M  COMMA  DOT  FSLH
+
+#define CAPS_WORD_CONTINUE_LIST Q

--- a/include/aekeynox/aliases/erglace.h
+++ b/include/aekeynox/aliases/erglace.h
@@ -62,3 +62,14 @@
 #define S_COMMA &kp G
 #define S_DOT   &kp X
 #define S_MONEY &kp RS(N1)
+
+/**
+* Caps-Word
+*/
+
+#define CAPS_WORD_SHIFT_LIST \
+    Q     E  R  T    Y  U  I  O  P \
+    A  S  D  F       H  J  K  L  SEMI \
+    Z        V  B    N  M  COMMA  DOT  FSLH
+
+#define CAPS_WORD_CONTINUE_LIST C W

--- a/include/aekeynox/aliases/ergol.h
+++ b/include/aekeynox/aliases/ergol.h
@@ -62,3 +62,14 @@
 #define S_COMMA &kp DOT
 #define S_DOT   &kp N
 #define S_MONEY &kp LS(N1)
+
+/**
+* Caps-Word
+*/
+
+#define CAPS_WORD_SHIFT_LIST \
+    Q  W  E  R  T    Y  U  I     P \
+    A  S  D  F  G    H  J  K  L  SEMI \
+    Z  X     V  B       M  COMMA       FSLH
+
+#define CAPS_WORD_CONTINUE_LIST O C

--- a/include/aekeynox/aliases/qwerty.h
+++ b/include/aekeynox/aliases/qwerty.h
@@ -62,3 +62,14 @@
 #define S_COMMA &kp COMMA
 #define S_DOT   &kp DOT
 #define S_MONEY &kp DLLR
+
+/**
+* Caps-Word
+*/
+
+#define CAPS_WORD_SHIFT_LIST \
+    Q  W  E  R  T    Y  U  I  O  P \
+    A  S  D  F  G    H  J  K  L \
+    Z  X  C  V  B    N  M
+
+#define CAPS_WORD_CONTINUE_LIST

--- a/include/aekeynox/aliases/qwerty_br.h
+++ b/include/aekeynox/aliases/qwerty_br.h
@@ -117,3 +117,14 @@
 #define C_NOT   &kp RA(N6)
 #define C_DEG   &kp RA(E)
 #define C_SILC  &kp RA(EQUAL)
+
+/**
+* Caps-Word
+*/
+
+#define CAPS_WORD_SHIFT_LIST \
+    Q  W  E  R  T    Y  U  I  O  P \
+    A  S  D  F  G    H  J  K  L \
+    Z  X  C  V  B    N  M
+
+#define CAPS_WORD_CONTINUE_LIST

--- a/include/aekeynox/aliases/qwerty_dk.h
+++ b/include/aekeynox/aliases/qwerty_dk.h
@@ -117,3 +117,14 @@
 #define C_POUND &kp RA(N3) // £
 #define C_SILC  &kp TILDE  // §
 #define C_MICRO &kp RA(M)  // µ
+
+/**
+* Caps-Word
+*/
+
+#define CAPS_WORD_SHIFT_LIST \
+    Q  W  E  R  T    Y  U  I  O  P \
+    A  S  D  F  G    H  J  K  L \
+    Z  X  C  V  B    N  M
+
+#define CAPS_WORD_CONTINUE_LIST

--- a/include/aekeynox/aliases/qwerty_ee.h
+++ b/include/aekeynox/aliases/qwerty_ee.h
@@ -156,3 +156,14 @@
 #define C_EURO  &kp RA(E)    // €
 #define C_POUND &kp RA(N3)   // £
 #define C_SILC  &kp RA(RBKT) // §
+
+/**
+* Caps-Word
+*/
+
+#define CAPS_WORD_SHIFT_LIST \
+    Q  W  E  R  T    Y  U  I  O  P \
+    A  S  D  F  G    H  J  K  L \
+    Z  X  C  V  B    N  M
+
+#define CAPS_WORD_CONTINUE_LIST

--- a/include/aekeynox/aliases/qwerty_es.h
+++ b/include/aekeynox/aliases/qwerty_es.h
@@ -125,3 +125,14 @@
 #define C_MDOT  &kp LS(N3) // ·
 #define C_NOT   &kp RA(N6) // ¬
 #define C_EURO  &kp RA(E)  // €
+
+/**
+* Caps-Word
+*/
+
+#define CAPS_WORD_SHIFT_LIST \
+    Q  W  E  R  T    Y  U  I  O  P \
+    A  S  D  F  G    H  J  K  L \
+    Z  X  C  V  B    N  M
+
+#define CAPS_WORD_CONTINUE_LIST

--- a/include/aekeynox/aliases/qwerty_intl.h
+++ b/include/aekeynox/aliases/qwerty_intl.h
@@ -185,3 +185,14 @@
 #define C_QRT2  &kp RA(N7)    // ½
 #define C_QRT3  &kp RA(N8)    // ¾
 #define C_MICRO &kp RA(M)     // µ
+
+/**
+* Caps-Word
+*/
+
+#define CAPS_WORD_SHIFT_LIST \
+    Q  W  E  R  T    Y  U  I  O  P \
+    A  S  D  F  G    H  J  K  L \
+    Z  X  C  V  B    N  M
+
+#define CAPS_WORD_CONTINUE_LIST

--- a/include/aekeynox/aliases/qwerty_it.h
+++ b/include/aekeynox/aliases/qwerty_it.h
@@ -136,3 +136,14 @@
 #define C_POUND &kp LS(N3)
 #define C_DEG   &kp DQT
 #define C_SILC  &kp PIPE
+
+/**
+* Caps-Word
+*/
+
+#define CAPS_WORD_SHIFT_LIST \
+    Q  W  E  R  T    Y  U  I  O  P \
+    A  S  D  F  G    H  J  K  L \
+    Z  X  C  V  B    N  M
+
+#define CAPS_WORD_CONTINUE_LIST

--- a/include/aekeynox/aliases/qwerty_lafayette.h
+++ b/include/aekeynox/aliases/qwerty_lafayette.h
@@ -74,3 +74,14 @@
     };
   };
 };
+
+/**
+* Caps-Word
+*/
+
+#define CAPS_WORD_SHIFT_LIST \
+    Q  W  E  R  T    Y  U  I  O  P \
+    A  S  D  F  G    H  J  K  L \
+    Z  X  C  V  B    N  M
+
+#define CAPS_WORD_CONTINUE_LIST

--- a/include/aekeynox/aliases/qwerty_latam.h
+++ b/include/aekeynox/aliases/qwerty_latam.h
@@ -120,3 +120,14 @@
 #define C_LCXE  &kp PLUS
 #define C_NOT   &kp RA(GRAVE)
 #define C_DEG   &kp TILDE
+
+/**
+* Caps-Word
+*/
+
+#define CAPS_WORD_SHIFT_LIST \
+    Q  W  E  R  T    Y  U  I  O  P \
+    A  S  D  F  G    H  J  K  L \
+    Z  X  C  V  B    N  M
+
+#define CAPS_WORD_CONTINUE_LIST

--- a/include/aekeynox/aliases/qwerty_no.h
+++ b/include/aekeynox/aliases/qwerty_no.h
@@ -116,3 +116,14 @@
 #define C_POUND &kp RA(N3) // £
 #define C_SILC  &kp TILDE  // §
 #define C_MICRO &kp RA(M)  // µ
+
+/**
+* Caps-Word
+*/
+
+#define CAPS_WORD_SHIFT_LIST \
+    Q  W  E  R  T    Y  U  I  O  P \
+    A  S  D  F  G    H  J  K  L \
+    Z  X  C  V  B    N  M
+
+#define CAPS_WORD_CONTINUE_LIST

--- a/include/aekeynox/aliases/qwerty_pt.h
+++ b/include/aekeynox/aliases/qwerty_pt.h
@@ -111,3 +111,14 @@
 #define C_EURO  &kp RA(E)  // €
 #define C_POUND &kp RA(N3) // £
 #define C_SILC  &kp RA(N4) // §
+
+/**
+* Caps-Word
+*/
+
+#define CAPS_WORD_SHIFT_LIST \
+    Q  W  E  R  T    Y  U  I  O  P \
+    A  S  D  F  G    H  J  K  L \
+    Z  X  C  V  B    N  M
+
+#define CAPS_WORD_CONTINUE_LIST

--- a/include/aekeynox/aliases/qwerty_se.h
+++ b/include/aekeynox/aliases/qwerty_se.h
@@ -125,3 +125,14 @@
 #define C_POUND &kp RA(N3) // £
 #define C_SILC  &kp GRAVE  // §
 #define C_MICRO &kp RA(M)  // µ
+
+/**
+* Caps-Word
+*/
+
+#define CAPS_WORD_SHIFT_LIST \
+    Q  W  E  R  T    Y  U  I  O  P \
+    A  S  D  F  G    H  J  K  L \
+    Z  X  C  V  B    N  M
+
+#define CAPS_WORD_CONTINUE_LIST

--- a/include/aekeynox/aliases/qwertz_ch.h
+++ b/include/aekeynox/aliases/qwertz_ch.h
@@ -116,3 +116,14 @@
 #define C_NOT   &kp RA(N6)
 #define C_DEG   &kp TILDE
 #define C_SILC  &kp GRAVE
+
+/**
+* Caps-Word
+*/
+
+#define CAPS_WORD_SHIFT_LIST \
+    Q  W  E  R  T    Y  U  I  O  P \
+    A  S  D  F  G    H  J  K  L \
+    Z  X  C  V  B    N  M
+
+#define CAPS_WORD_CONTINUE_LIST

--- a/include/aekeynox/aliases/qwertz_de.h
+++ b/include/aekeynox/aliases/qwertz_de.h
@@ -105,3 +105,14 @@
 #define C_NOT   S_MINUS   // unsupported
 #define C_DEG   &kp TILDE
 #define C_SILC  &kp LS(N3)
+
+/**
+* Caps-Word
+*/
+
+#define CAPS_WORD_SHIFT_LIST \
+    Q  W  E  R  T    Y  U  I  O  P \
+    A  S  D  F  G    H  J  K  L \
+    Z  X  C  V  B    N  M
+
+#define CAPS_WORD_CONTINUE_LIST

--- a/include/aekeynox/hold_taps.dtsi
+++ b/include/aekeynox/hold_taps.dtsi
@@ -235,7 +235,7 @@
     OMIT_IF_NO_REF shift_caps: shift_caps {
       compatible = "zmk,behavior-mod-morph";
       #binding-cells = <0>;
-      bindings  = <&EZ_SK(LSHIFT)>, <&kp CAPS>;
+      bindings  = <&EZ_SK(LSHIFT)>, <&caps_word>;
       mods      = <(MOD_LSFT)>;
     };
 

--- a/include/aekeynox/mappings.dtsi
+++ b/include/aekeynox/mappings.dtsi
@@ -40,7 +40,7 @@
   continue-list = <CAPS_WORD_CONTINUE_LIST>;
   no-default-keys;
   mods = <MOD_RSFT>;  // caps-word uses right shift in case we want to
-                      // diffrenciate it from regular shift
+                      // differentiate it from regular shift
 };
 
 / {

--- a/include/aekeynox/mappings.dtsi
+++ b/include/aekeynox/mappings.dtsi
@@ -35,6 +35,14 @@
   mods = <(MOD_LSFT|MOD_RSFT)>;                                      \
 };
 
+&caps_word {
+  shift-list = <CAPS_WORD_SHIFT_LIST>;
+  continue-list = <CAPS_WORD_CONTINUE_LIST>;
+  no-default-keys;
+  mods = <MOD_RSFT>;  // caps-word uses right shift in case we want to
+                      // diffrenciate it from regular shift
+};
+
 / {
   behaviors {
     TWO_LEVEL_KEY(bt_sel1_clr, &bt BT_SEL 1, &bt BT_CLR)


### PR DESCRIPTION
Adds a simple integration for a `caps_word` behavior, using an [unmerged PR](https://github.com/zmkfirmware/zmk/pull/1742) I’ve backported into our fork.