### PR TITLE
Fix fancy dead key for split hummingbirds

### DIFF
--- a/include/aekeynox/selenium.keymap
+++ b/include/aekeynox/selenium.keymap
@@ -152,7 +152,7 @@
   #include "emulations/qwerty_lafayette.dtsi"
 
 // Experimental Ergol variant for Hummingbird-style keyboards
-#elif defined KB_LAYOUT_ERGOL && defined HUMMINGBIRD
+#elif defined KB_LAYOUT_ERGOL && defined ENABLE_HUMMINGBIRD_MODE
   #include "extra_layers/ergol_hummingbird.dtsi"
 
 // Some layouts require extra layers to fit on a 3×10 grid

--- a/include/aekeynox/settings.h
+++ b/include/aekeynox/settings.h
@@ -171,3 +171,13 @@
 // Beware: this increases the typing load of the left thumb.
 
 // #define LEFT_HAND_SPACE
+
+// [Experimental]
+// Uncomment the following line to enable a hummingbird-style adaptation of
+// your keyboard layout. Keys that are originally on the ZBN/ QWERTY-positions
+// will be duplicated on a 1dk layer. This reduces the number of keys required to
+// write texts, and thus limits finger movement (at the cost of a couple of extra
+// keystrokes). The adaptations are layout-specific; as of today, only Ergol is
+// supported.
+
+// #define ENABLE_HUMMINGBIRD_MODE

--- a/src/behaviors/behavior_dead_key.c
+++ b/src/behaviors/behavior_dead_key.c
@@ -31,6 +31,9 @@ struct behavior_dead_key_data {
     uint32_t dead_key;
     uint32_t base_letter;
     bool is_down;
+    #if IS_ENABLED(CONFIG_ZMK_SPLIT)
+    uint8_t source;
+    #endif
 };
 
 static struct behavior_dead_key_data active_dead_key;
@@ -57,6 +60,9 @@ static int on_dead_key_binding_pressed(
         .dead_key = cfg->dead_key,
         .base_letter = binding->param1,
         .is_down = true,
+        #if IS_ENABLED(CONFIG_ZMK_SPLIT)
+        .source = event.source,
+        #endif
     };
 
     const zmk_mod_flags_t mods_after = zmk_hid_get_explicit_mods();
@@ -117,7 +123,7 @@ static int dead_key_keycode_state_changed_listener(const zmk_event_t *eh) {
         .position = active_dead_key.position,
         .timestamp = ev->timestamp,
         #if IS_ENABLED(CONFIG_ZMK_SPLIT)
-        .source = ev->source,
+        .source = active_dead_key.source,
         #endif
     };
 

--- a/tests.yaml
+++ b/tests.yaml
@@ -23,7 +23,7 @@ include:
     # Ergol + Hummingbird
   - board: quacken_flex/rp2040
     artifact-name: ergol_hummingbird
-    cmake-args: -DDTS_EXTRA_CPPFLAGS="-DCI_IGNORE_USER_SETTINGS;-DKB_LAYOUT_ERGOL;-DHUMMINGBIRD"
+    cmake-args: -DDTS_EXTRA_CPPFLAGS="-DCI_IGNORE_USER_SETTINGS;-DKB_LAYOUT_ERGOL;-DHUMMINGBIRD;-DENABLE_FANCY_DEAD_KEYS"
 
     # Ensure the Ferris applies 2TK even when HRM is requested
   - board: ferris//zmk


### PR DESCRIPTION
fixes #134 

This PR fixes a couple of issues in the hummingbird adaptation for ergol:
- the fancy dead-key wouldn’t compile on a split keyboard
- the hummingbird flag wasn’t exported in the settings (despite the hummingbird being supported)
- the flag checked to enable this mode was still `HUMMINGBIRD` instead of the new one (it seems I messed up a rebase)