### PR TITLE
QWERTZ-sk (Slovakia)

### DIFF
--- a/include/aekeynox/README.md
+++ b/include/aekeynox/README.md
@@ -105,13 +105,13 @@ common errors you may encounter and what they mean:
 - `expected number or parenthesized expression`<br>
   a key/layer/modifier/macro is  missing or ill-defined
   (check that you or a macro didn’t accidentally add an extra `&`)
-  
+
 - `<Node … in …/empty_file.c> lacks #binding-cells`<br>
   a behavior in a `bindings` property has too few parameters
-  
+
 - `binding controller <Node <behavior> in …/empty_file.c> lacks binding`<br>
   the `compatible` field in the declaration of `behavior` is missing or incorrect
-  
+
 - `'DT_N_S_keymap_S_<layer_name>_P_bindings_IDX_<n>_PH_FULL_NAME' undeclared here`<br>
   same as the first one, but caught later in the compilation and much more precise,
   as it tells you the issue resides with the `n`th key of `layer_name`

--- a/include/aekeynox/aliases.h
+++ b/include/aekeynox/aliases.h
@@ -59,6 +59,8 @@
   #include "aliases/qwertz_cz.h"
 #elifdef KB_LAYOUT_QWERTZ_DE
   #include "aliases/qwertz_de.h"
+#elifdef KB_LAYOUT_QWERTZ_SK
+  #include "aliases/qwertz_sk.h"
 
 // Alternative Layouts
 #elifdef KB_LAYOUT_BEPO

--- a/include/aekeynox/aliases/dead_keys.h
+++ b/include/aekeynox/aliases/dead_keys.h
@@ -45,6 +45,9 @@
     #ifndef SC_YACU
     #define SC_YACU CP1252_UPPERCASE_Y_ACUTE
     #endif
+    #ifndef  C_LACU
+    #define  C_LACU CP1252_LOWERCASE_Y_ACUTE
+    #endif
   #endif
 #endif
 
@@ -83,6 +86,18 @@
 #endif
 #ifndef SC_YACU
 #define SC_YACU DI_ACU RS(Y)
+#endif
+#ifndef  C_LACU
+#define  C_LACU DI_ACU L
+#endif
+#ifndef SC_LACU
+#define SC_LACU DI_ACU RS(L)
+#endif
+#ifndef  C_RACU
+#define  C_RACU DI_ACU R
+#endif
+#ifndef SC_RACU
+#define SC_RACU DI_ACU RS(R)
 #endif
 
 /**
@@ -480,6 +495,12 @@
 #endif
 #ifndef SC_ECAR
 #define SC_ECAR DI_CAR RS(E)
+#endif
+#ifndef  C_LCAR
+#define  C_LCAR DI_CAR L
+#endif
+#ifndef SC_LCAR
+#define SC_LCAR DI_CAR RS(L)
 #endif
 #ifndef  C_NCAR
 #define  C_NCAR DI_CAR N

--- a/include/aekeynox/aliases/dead_keys.h
+++ b/include/aekeynox/aliases/dead_keys.h
@@ -45,9 +45,6 @@
     #ifndef SC_YACU
     #define SC_YACU CP1252_UPPERCASE_Y_ACUTE
     #endif
-    #ifndef  C_LACU
-    #define  C_LACU CP1252_LOWERCASE_Y_ACUTE
-    #endif
   #endif
 #endif
 

--- a/include/aekeynox/aliases/qwertz_sk.h
+++ b/include/aekeynox/aliases/qwertz_sk.h
@@ -1,5 +1,5 @@
-// Czechia
-// https://kbdlayout.info/kbdcz
+// Slovakia
+// https://kbdlayout.info/kbdsl
 
 /**
  * Action Combos
@@ -21,49 +21,47 @@
 
 #define SA(key) RA(RS(key))
 
-#if LINUX // same as SK
+#if LINUX // same as CZ
   #define DEAD_ABOVE_RING TILDE
   #define DEAD_CARON      SA(N2)
   #define DEAD_CIRCUMFLEX SA(N3)
   #define DEAD_GRAVE      SA(N7)
   #define DEAD_ACUTE      SA(N9)
+  #define DEAD_DIAERESIS  SA(MINUS)
 #else
-  #define DEAD_ABOVE_RING RA(TILDE)
+  #define DEAD_ABOVE_RING TILDE
   #define DEAD_CARON      RA(N2)
   #define DEAD_CIRCUMFLEX RA(N3)
-  #define DEAD_GRAVE      RA(N7)
   #define DEAD_ACUTE      RA(N9)
+  #define DEAD_DIAERESIS  RA(MINUS)
 #endif
 
-#define DEAD_DIAERESIS  BSLH
+// Note: on Windows, CapsLock does not work on these letters below.
 
-// áéíúý
-#define  C_AACU   &kp N8
-#define SC_AACU &caps N8
-#define  C_EACU   &kp N0
-#define SC_EACU &caps N0
-#define  C_IACU   &kp N9
-#define SC_IACU &caps N9
-#define  C_UACU   &kp LBKT
-#define SC_UACU &caps LBKT
-#define  C_YACU   &kp N7
-#define SC_YACU &caps N7
+// caron/mäkčeň: ľščťž (ščž same as CZ)
+#define C_LCAR  &kp N2
+#define C_SCAR  &kp N3
+#define C_CCAR  &kp N4
+#define C_TCAR  &kp N5
+#define C_ZCAR  &kp N6
+#define C_NCAR  &kp BSLH
 
-// čěřšž
-#define  C_CCAR   &kp N4
-#define SC_CCAR &caps N4
-#define  C_ECAR   &kp N2
-#define SC_ECAR &caps N2
-#define  C_RCAR   &kp N5
-#define SC_RCAR &caps N5
-#define  C_SCAR   &kp N3
-#define SC_SCAR &caps N3
-#define  C_ZCAR   &kp N6
-#define SC_ZCAR &caps N6
+// acute accent: ýáíéú (same as CZ)
+#define C_YACU  &kp N7
+#define C_AACU  &kp N8
+#define C_IACU  &kp N9
+#define C_EACU  &kp N0
+#define C_UACU  &kp LBKT
 
-// ů
-#define  C_URNG   &kp SEMI
-#define SC_URNG &caps SEMI
+// circumflex: ô
+#define C_OCIR  &kp SEMI
+
+// diaeresis: ä
+#define C_ADIA  &kp RBKT
+
+// QWERTZ…
+#define SC_ZCAR  DI_CAR LS(Y)
+#define SC_YACU  DI_ACU LS(Z)
 
 // Shift+1dk keeps the default behavior
 #define SC_ODK  &kp COLON
@@ -79,11 +77,13 @@
 
 #if LINUX
   #define S_CARET &kp RA(N6)
+  #define S_SQT   &kp RA(J)
   #define S_GRAVE &kp RA(GRAVE)
   #define S_TILDE &kp RA(TILDE)
 #else
   #define S_CARET DI_CIR SPACE
-  #define S_GRAVE DI_GRV SPACE
+  #define S_SQT   &kp RA(P)
+  #define S_GRAVE &kp RA(N7)
   #define S_TILDE &kp RA(N1)
 #endif
 
@@ -96,16 +96,16 @@
 #define S_AT    &kp RA(V)
 #define S_AMPS  &kp RA(C)
 #define S_STAR  &kp RA(FSLH)
-#define S_SQT   &kp PIPE
+// XXX: S_SQT   is OS-specific
 // XXX: S_GRAVE is OS-specific
 
 // second row
 #define S_LBRC  &kp RA(B)
 #define S_LPAR  &kp RBRC
-#define S_RPAR  &kp RBKT
+#define S_RPAR  &kp PIPE
 #define S_RBRC  &kp RA(N)
 #define S_EQUAL &kp MINUS
-#define S_BSLH  &kp NUBS
+#define S_BSLH  &kp RA(Q)
 #define S_PLUS  &kp N1
 #define S_MINUS &kp FSLH
 #define S_FSLH  &kp LBRC
@@ -117,7 +117,7 @@
 #define S_RBKT  &kp RA(G)
 #define S_UNDER &kp QMARK
 #define S_HASH  &kp RA(X)
-#define S_PIPE  &kp PIPE2
+#define S_PIPE  &kp RA(W)
 #define S_EXCL  &kp DQT
 #define S_SEMI  &kp GRAVE
 #define S_COLON &kp LS(DOT)

--- a/include/aekeynox/extra_layers/README.md
+++ b/include/aekeynox/extra_layers/README.md
@@ -27,6 +27,7 @@ When possible, it’s placed on the `SEMI` key (QWERTY’s <kbd>;:</kbd> key).
   - [AZERTY-1dk](#azerty-1dk)
   - [Bépolar](#bépolar)
   - [QWERTZ-cz-1dk](#qwertz-cz-1dk): Czechia
+  - [QWERTZ-sk-1dk](#qwertz-sk-1dk): Slovakia
   - [Other Layouts](#other-layouts)
 - [Six-Column Configurations](#six-column-configurations)
   - [QWERTY-intl](#qwerty-intl)
@@ -316,10 +317,43 @@ QWERTZ-cz-1dk replaces the <kbd>ů</kbd> key with <kbd>1dk</kbd>:
     |---------------|---------------|
 ```
 
-- 1dk is a dead acute accent on vowels (á, é, í, ó, ú, ý)
 - 1dk is a dead caron/háček on consonants (č, ď, ň, ř, š, ť, ž)
+- 1dk is a dead acute accent on vowels (á, é, í, ó, ú, ý)
 - 1dk is a dead ring below U (ů)
 - exception: ě (caron/háček) left to E
+
+### QWERTZ-sk-1dk
+
+- [x] [`KB_LAYOUT_QWERTZ_SK`]: Slovakia
+
+QWERTZ-sk-1dk replaces the <kbd>ô</kbd> key with <kbd>1dk</kbd>:
+
+```
+    |---------------|---------------|  base
+    |    q w e r t  |  z u i o p    |
+    |    a s d f g  |  h j k l *    |
+    |    z x c v b  |  n m , . -    |
+    |---------------|---------------|
+
+    |---------------|---------------|  1dk
+    |    ä ě é ř ť  |  ž ú í ó      |
+    |    á š ď ŕ    |    ů ô ľ ˝    |
+    |    ý ß č      |  ň     ĺ      |
+    |---------------|---------------|
+
+    |---------------|---------------|  1dkShift
+    |    Ä Ě É Ř Ť  |  Ž Ú Í Ó      |
+    |    Á Š Ď Ŕ    |    Ů Ô Ľ ˝    |
+    |    Ý § Č      |  Ň     Ĺ      |
+    |---------------|---------------|
+```
+
+- 1dk is a dead caron/mäkčeň on consonants (č, ď, ľ, ň, ř, š, ť, ž)
+- 1dk is a dead acute accent on vowels (á, é, í, ó, ú, ý)
+- 1dk is a dead acute accent below consonants (ĺ, ŕ)
+- 1dk is a dead diaeresis above A (ä)
+- exception: ô (circumflex) on K
+- compatibility with Czech: ů (ring) below U, ě (caron/mäkčeň) left to E
 
 ### Other Layouts
 

--- a/include/aekeynox/extra_layers/qwertz_sk_1dk.dtsi
+++ b/include/aekeynox/extra_layers/qwertz_sk_1dk.dtsi
@@ -1,0 +1,50 @@
+#include "1dk.dtsi"
+
+/**
+ * This adds a dead key (1dk) to access all common Slovak chars:
+ *  - 1dk is a dead caron/mäkčeň on consonants (č, ď, ľ, ň, ř, š, ť, ž)
+ *  - 1dk is a dead acute accent on vowels (á, é, í, ó, ú, ý)
+ *  - 1dk is a dead acute accent below consonants (ĺ, ŕ)
+ *  - 1dk is a dead diaeresis above A (ä)
+ *  - exception: ô (circumflex) on K
+ *  - compatibility with Czech: ů (ring) below U, ě (caron/mäkčeň) left to E
+**/
+
+/ {
+  keymap {
+    compatible = "zmk,keymap";
+
+    //  |---------------|---------------|
+    //  |    ä ě é ř ť  |  ž ú í ó      |
+    //  |    á š ď ŕ    |    ů ô ľ ¨    |
+    //  |    ý ß č      |  ň     ĺ      |
+    //  |---------------|---------------|
+
+    one_dead_key {
+      display-name = "1dk";
+      bindings = <SELENIUM_KEYMAP_BINDINGS(
+        &trans  ,  C_ADIA  C_ECAR  C_EACU  C_RCAR  C_TCAR   ,   C_ZCAR  C_UACU  C_IACU  C_OACU  &none   ,  &trans ,
+        &trans  ,  C_AACU  C_SCAR  C_DCAR  C_RACU  &none    ,   &none   C_URNG  C_OCIR  C_LCAR  DK_DIA  ,  &trans ,
+        K_ODKS  ,  C_YACU  C_SZ    C_CCAR  &none   &none    ,   C_NCAR  &none   &none   C_LACU  &none   ,  K_ODKS ,
+                                 SK_ODKS , S_SQT , &trans   ,   &trans , S_SQT , &trans
+      )>;
+    };
+
+    //  |---------------|---------------|
+    //  |    Ä Ě É Ř Ť  |  Ž Ú Í Ó      |
+    //  |    Á Š Ď Ŕ    |    Ů Ô Ľ ¨    |
+    //  |    Ý § Č      |  Ň     Ĺ      |
+    //  |---------------|---------------|
+
+    one_dead_key_shift {
+      display-name = "1dkShift";
+      bindings = <SELENIUM_KEYMAP_BINDINGS(
+        &trans  ,  SC_ADIA SC_ECAR SC_EACU SC_RCAR SC_TCAR  ,   SC_ZCAR SC_UACU SC_IACU SC_OACU &none   ,  &trans ,
+        &trans  ,  SC_AACU SC_SCAR SC_DCAR SC_RACU &none    ,   &none   SC_URNG SC_OCIR SC_LCAR DK_DIA  ,  &trans ,
+        &trans  ,  SC_YACU C_SILC  SC_CCAR &none   &none    ,   SC_NCAR &none   &none   SC_LACU &none   ,  &trans ,
+                                 &trans , &trans , &trans   ,   &trans , &trans , &trans
+      )>;
+    };
+
+  };
+};

--- a/include/aekeynox/selenium.keymap
+++ b/include/aekeynox/selenium.keymap
@@ -163,6 +163,8 @@
     #include "extra_layers/bepolar.dtsi"
   #elif defined KB_LAYOUT_QWERTZ_CZ
     #include "extra_layers/qwertz_cz_1dk.dtsi"
+  #elif defined KB_LAYOUT_QWERTZ_SK
+    #include "extra_layers/qwertz_sk_1dk.dtsi"
   #elif defined KB_EXTRA_LAYERS_ALTGR
     #include "extra_layers/altgr_1dk.dtsi" // default for LV, PL, RO
   #elif defined KB_EXTRA_LAYERS_NORDIC

--- a/include/aekeynox/settings.h
+++ b/include/aekeynox/settings.h
@@ -34,6 +34,7 @@
 // #define KB_LAYOUT_QWERTZ_CH_FR      // Switzerland (French)
 // #define KB_LAYOUT_QWERTZ_CZ         // Czechia
 // #define KB_LAYOUT_QWERTZ_DE         // Germany, Austria
+// #define KB_LAYOUT_QWERTZ_SK         // Slovakia
 
 // Some keyboard layouts and shortcuts may vary between Windows / macOS / Linux.
 // Uncomment one of the following lines if the host computer doen't run Windows.

--- a/tests.yaml
+++ b/tests.yaml
@@ -114,7 +114,7 @@ include:
     artifact-name: qwertz_ch_de
     cmake-args: -DDTS_EXTRA_CPPFLAGS="-DCI_IGNORE_USER_SETTINGS;-DKB_LAYOUT_QWERTZ_CH_DE"
 
-    # QWERTZ-cz (Czech Republic)
+    # QWERTZ-cz (Czechia)
   - board: quacken_flex/rp2040
     artifact-name: qwertz_cz
     cmake-args: -DDTS_EXTRA_CPPFLAGS="-DCI_IGNORE_USER_SETTINGS;-DKB_LAYOUT_QWERTZ_CZ;-DLINUX"
@@ -123,6 +123,11 @@ include:
   - board: quacken_flex/rp2040
     artifact-name: qwertz_de
     cmake-args: -DDTS_EXTRA_CPPFLAGS="-DCI_IGNORE_USER_SETTINGS;-DKB_LAYOUT_QWERTZ_DE"
+
+    # QWERTZ-sk (Slovakia)
+  - board: quacken_flex/rp2040
+    artifact-name: qwertz_sk
+    cmake-args: -DDTS_EXTRA_CPPFLAGS="-DCI_IGNORE_USER_SETTINGS;-DKB_LAYOUT_QWERTZ_SK"
 
   ###
   # Layout Emulations


### PR DESCRIPTION
<img width="1000" height="333" alt="image" src="https://github.com/user-attachments/assets/db568ac7-0ad3-4ef2-9a18-44a45dcc48b5" />

- acute accent: `áéíĺóŕúý`
- caron/mäkčeň: `čďľňšťž` (in `dž`)
- diaeresis:    `ä`
- circumflex:   `ô`

https://en.wikipedia.org/wiki/Slovak_orthography
https://kbdlayout.info/kbdsl