### PR TITLE
fix: deduplicate include statements to avoid overrides.

### DIFF
--- a/include/aekeynox/aliases.h
+++ b/include/aekeynox/aliases.h
@@ -1,4 +1,3 @@
-#include <dt-bindings/zmk/keys.h>
 #include <dt-bindings/zmk/pointing.h>
 
 

--- a/include/aekeynox/extra_layers/bepolar.dtsi
+++ b/include/aekeynox/extra_layers/bepolar.dtsi
@@ -1,9 +1,6 @@
 #define ODK_LAYER        EXTRA_LAYERS_START_INDEX
 #define ODK_SHIFT_LAYER (EXTRA_LAYERS_START_INDEX + 1)
 
-#define  K_ODKS    &mo ODK_SHIFT_LAYER  // Shift key in the 1dk layer
-#define SK_ODKS &EZ_SL(ODK_SHIFT_LAYER) // Shift key in the 1dk layer (sticky)
-
 #define SA(key) RS(RA(key))
 
 // Override the default base layer to apply Bepolar over a Bepo host ([N] becomes 1DK).
@@ -34,7 +31,15 @@
       keep-mods = <(MOD_LSFT|MOD_RSFT)>;
     };
 
-    DEAD_KEY(kpc, Y)  // circumflex accent
+    #ifdef ENABLE_FANCY_DEAD_KEYS
+      DEAD_KEY(kpc, Y)  // circumflex accent
+      #define  K_ODKS    &kp LEFT_SHIFT
+      #define SK_ODKS &EZ_SK(LEFT_SHIFT)
+    #else
+      #define kpc digraph Y
+      #define  K_ODKS    &mo ODK_SHIFT_LAYER  // Shift key in the 1dk layer
+      #define SK_ODKS &EZ_SL(ODK_SHIFT_LAYER) // Shift key in the 1dk layer (sticky)
+    #endif
     DEAD_KEY_SHIFT(skpc, Y)
   };
 

--- a/include/aekeynox/hold_taps.dtsi
+++ b/include/aekeynox/hold_taps.dtsi
@@ -1,7 +1,3 @@
-#include <behaviors.dtsi>
-#include <dt-bindings/zmk/keys.h>
-#include <behaviors/mod-hold.dtsi>
-
 // clang-format off
 
 /**

--- a/include/aekeynox/mappings.dtsi
+++ b/include/aekeynox/mappings.dtsi
@@ -1,26 +1,7 @@
-#include <behaviors.dtsi>
-#include <dt-bindings/zmk/keys.h>
+// clang-format off
 
-#ifdef ENABLE_FANCY_DEAD_KEYS
-  // This header file provides a DEAD_KEY macro to quicly declare
-  // fancy dead-key behaviors.
-  #include <behaviors/dead-key.dtsi>
-#else
-  // Fallback using a simple one-param macro
-  #define DEAD_KEY(name, key) OMIT_IF_NO_REF name: name { \
-    compatible = "zmk,behavior-macro-one-param";          \
-    #binding-cells = <1>;                                 \
-    tap-ms = <0>;                                         \
-    wait-ms = <0>;                                        \
-    bindings                                              \
-      = <&macro_tap &kp key>                              \
-      , <&macro_param_1to1 &kp MACRO_PLACEHOLDER>         \
-      ;                                                   \
-  };
-#endif
-
-// Same as the DEAD_KEY fallback, but with the following key shifted.
-// Must be unconditionnaly defined for as long as odk-shift layers use it.
+// Convenience macro to help define ocasionnal dead-key -> shifted-key mappings.
+// Mostly a legacy feature for layouts who didn’t have the proper aliases yet.
 #define DEAD_KEY_SHIFT(name, key) OMIT_IF_NO_REF name: name { \
   compatible = "zmk,behavior-macro-one-param";                \
   #binding-cells = <1>;                                       \

--- a/include/aekeynox/selenium.keymap
+++ b/include/aekeynox/selenium.keymap
@@ -1,7 +1,14 @@
 // Selenium keymap:
 // https://github.com/OneDeadKey/selenium
 
-#include <dt-bindings/zmk/bt.h> // bluetooth behaviors (see fn/media layer)
+// Standard ZMK headers
+#include <behaviors.dtsi>         // standard behaviors defined by ZMK
+#include <dt-bindings/zmk/keys.h> // human-readable keycodes and modifiers
+#include <dt-bindings/zmk/bt.h>   // bluetooth behaviors (see fn/media layer)
+
+// Community module headers
+#include <behaviors/mod-hold.dtsi> // Provides helper macros for the mod-hold behavior
+#include <behaviors/dead-key.dtsi> // Provides helper macros for the dead-key behavior
 
 #ifndef CI_IGNORE_USER_SETTINGS
   #include "settings.h"   // user settings


### PR DESCRIPTION
Most of those `.dtsi` files don’t actually have header guards. If you override a couple of properties in a behavior then reimport the header, you run the risk of having those properties being reset to their original values.