### PR TITLE
add a macro to deactivate sticky left shift before activating capsword

### DIFF
--- a/include/aekeynox/hold_taps.dtsi
+++ b/include/aekeynox/hold_taps.dtsi
@@ -232,8 +232,14 @@
     OMIT_IF_NO_REF shift_caps: shift_caps {
       compatible = "zmk,behavior-mod-morph";
       #binding-cells = <0>;
-      bindings  = <&EZ_SK(LSHIFT)>, <&caps_word>;
+      bindings  = <&EZ_SK(LSHIFT)>, <&unshift_caps>;
       mods      = <(MOD_LSFT)>;
+    };
+    // removes Sticky Left Shift before activating caps word
+    OMIT_IF_NO_REF unshift_caps: unshift_caps {
+      compatible = "zmk,behavior-macro";
+      #binding-cells = <0>;
+      bindings = <&macro_tap &kp K_CANCEL>, <&caps_word>;
     };
 
     // mod-morphs to restore Shift+Space and Ctrl+Backspace for certain keymaps


### PR DESCRIPTION
fix #148 