### PR TITLE
fix(timings): make `&bsk`s roll-safe again, fixes #150

### DIFF
--- a/include/aekeynox/hold_taps.dtsi
+++ b/include/aekeynox/hold_taps.dtsi
@@ -224,7 +224,6 @@
       tapping-term-ms = <TAPPING_TERM>;
       flavor = "tap-preferred";
       bindings = <&kp>, <&osm>;
-      hold-while-undecided-linger;
       hold-while-undecided;
     };
 


### PR DESCRIPTION
Deactvate the `hold-while-undecided-linger` flag for the `bsk` behavior, as this will make the modifier stay active for as long as the key is held. This may caus the `osm` to apply to multiple keys, rendering the `bsk` effectively useless.